### PR TITLE
Feat/cow str

### DIFF
--- a/crates/zoon/src/cow_str.rs
+++ b/crates/zoon/src/cow_str.rs
@@ -1,0 +1,86 @@
+use std::borrow::Cow;
+
+// ------ ------
+//  IntoCowStr
+// ------ ------
+
+pub trait IntoCowStr<'a> {
+    fn into_cow_str(self) -> Cow<'a, str>;
+
+    fn into_cow_str_wrapper(self) -> CowStrWrapper<'a> where Self: Sized {
+        CowStrWrapper(self.into_cow_str())
+    }
+}
+
+impl<'a> IntoCowStr<'a> for String {
+    fn into_cow_str(self) -> Cow<'a, str> {
+        self.into()
+    }
+}
+
+impl<'a> IntoCowStr<'a> for &'a String {
+    fn into_cow_str(self) -> Cow<'a, str> {
+        self.into()
+    }
+}
+
+impl<'a> IntoCowStr<'a> for &'a str {
+    fn into_cow_str(self) -> Cow<'a, str> {
+        self.into()
+    }
+}
+
+impl<'a> IntoCowStr<'a> for Cow<'a, str> {
+    fn into_cow_str(self) -> Cow<'a, str> {
+        self
+    }
+}
+
+macro_rules! make_into_cow_str_impls {
+    ($($type:ty),*) => (
+        $(
+        impl<'a> IntoCowStr<'a> for $type {
+            fn into_cow_str(self) -> Cow<'a, str> {
+                self.to_string().into()
+            }
+        }
+        )*
+    )
+}
+make_into_cow_str_impls!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
+
+// -------- --------
+// IntoOptionCowStr
+// -------- --------
+
+pub trait IntoOptionCowStr<'a> {
+    fn into_option_cow_str(self) -> Option<Cow<'a, str>>;
+
+    fn into_option_cow_str_wrapper(self) -> Option<CowStrWrapper<'a>> where Self: Sized {
+        self.into_option_cow_str().map(|this| this.into_cow_str_wrapper())
+    }
+}
+
+impl<'a, T: IntoCowStr<'a>> IntoOptionCowStr<'a> for T {
+    fn into_option_cow_str(self) -> Option<Cow<'a, str>> {
+        Some(self.into_cow_str())
+    }
+}
+
+impl<'a, T: IntoCowStr<'a>> IntoOptionCowStr<'a> for Option<T> {
+    fn into_option_cow_str(self) -> Option<Cow<'a, str>> {
+        self.map(|this| this.into_cow_str())
+    }
+}
+
+// ------ ------
+// CowStrWrapper
+// ------ ------
+
+pub struct CowStrWrapper<'a>(Cow<'a, str>);
+
+impl dominator::traits::AsStr for CowStrWrapper<'_> {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}

--- a/crates/zoon/src/cow_str.rs
+++ b/crates/zoon/src/cow_str.rs
@@ -7,7 +7,10 @@ use std::borrow::Cow;
 pub trait IntoCowStr<'a> {
     fn into_cow_str(self) -> Cow<'a, str>;
 
-    fn into_cow_str_wrapper(self) -> CowStrWrapper<'a> where Self: Sized {
+    fn into_cow_str_wrapper(self) -> CowStrWrapper<'a>
+    where
+        Self: Sized,
+    {
         CowStrWrapper(self.into_cow_str())
     }
 }
@@ -56,8 +59,12 @@ make_into_cow_str_impls!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128
 pub trait IntoOptionCowStr<'a> {
     fn into_option_cow_str(self) -> Option<Cow<'a, str>>;
 
-    fn into_option_cow_str_wrapper(self) -> Option<CowStrWrapper<'a>> where Self: Sized {
-        self.into_option_cow_str().map(|this| this.into_cow_str_wrapper())
+    fn into_option_cow_str_wrapper(self) -> Option<CowStrWrapper<'a>>
+    where
+        Self: Sized,
+    {
+        self.into_option_cow_str()
+            .map(|this| this.into_cow_str_wrapper())
     }
 }
 

--- a/crates/zoon/src/element/raw_el.rs
+++ b/crates/zoon/src/element/raw_el.rs
@@ -76,11 +76,11 @@ where
     pub fn attr_signal(
         mut self,
         name: impl ToString,
-        value: impl Signal<Item = Option<impl ToString>> + Unpin + 'static,
+        value: impl Signal<Item = impl IntoOptionCowStr<'a>> + Unpin + 'static,
     ) -> Self {
         self.dom_builder = self.dom_builder.attribute_signal(
             name.to_string(),
-            value.map(|value| value.map(|value| value.to_string())),
+            value.map(|value| value.into_option_cow_str_wrapper()),
         );
         self
     }

--- a/crates/zoon/src/element/raw_el.rs
+++ b/crates/zoon/src/element/raw_el.rs
@@ -75,11 +75,11 @@ where
 
     pub fn attr_signal(
         mut self,
-        name: impl ToString,
+        name: impl IntoCowStr<'static>,
         value: impl Signal<Item = impl IntoOptionCowStr<'a>> + Unpin + 'static,
     ) -> Self {
         self.dom_builder = self.dom_builder.attribute_signal(
-            name.to_string(),
+            name.into_cow_str_wrapper(),
             value.map(|value| value.into_option_cow_str_wrapper()),
         );
         self

--- a/crates/zoon/src/element/raw_text.rs
+++ b/crates/zoon/src/element/raw_text.rs
@@ -15,9 +15,9 @@ impl RawText {
         }
     }
 
-    pub fn with_signal(text: impl Signal<Item = impl ToString> + Unpin + 'static) -> Self {
+    pub fn with_signal<'a>(text: impl Signal<Item = impl IntoCowStr<'a>> + Unpin + 'static) -> Self {
         Self {
-            dom: dominator::text_signal(text.map(|text| text.to_string())),
+            dom: dominator::text_signal(text.map(|text| text.into_cow_str_wrapper())),
         }
     }
 }

--- a/crates/zoon/src/element/raw_text.rs
+++ b/crates/zoon/src/element/raw_text.rs
@@ -15,7 +15,9 @@ impl RawText {
         }
     }
 
-    pub fn with_signal<'a>(text: impl Signal<Item = impl IntoCowStr<'a>> + Unpin + 'static) -> Self {
+    pub fn with_signal<'a>(
+        text: impl Signal<Item = impl IntoCowStr<'a>> + Unpin + 'static,
+    ) -> Self {
         Self {
             dom: dominator::text_signal(text.map(|text| text.into_cow_str_wrapper())),
         }

--- a/crates/zoon/src/element/text.rs
+++ b/crates/zoon/src/element/text.rs
@@ -16,7 +16,9 @@ impl Text {
         }
     }
 
-    pub fn with_signal<'a>(text: impl Signal<Item = impl IntoCowStr<'a>> + Unpin + 'static) -> Self {
+    pub fn with_signal<'a>(
+        text: impl Signal<Item = impl IntoCowStr<'a>> + Unpin + 'static,
+    ) -> Self {
         Self {
             raw_text: RawText::with_signal(text),
         }

--- a/crates/zoon/src/element/text.rs
+++ b/crates/zoon/src/element/text.rs
@@ -16,7 +16,7 @@ impl Text {
         }
     }
 
-    pub fn with_signal(text: impl Signal<Item = impl ToString> + Unpin + 'static) -> Self {
+    pub fn with_signal<'a>(text: impl Signal<Item = impl IntoCowStr<'a>> + Unpin + 'static) -> Self {
         Self {
             raw_text: RawText::with_signal(text),
         }
@@ -28,51 +28,6 @@ impl Element for Text {
         self.raw_text.into()
     }
 }
-
-// ------ ------
-//     ToStr
-// ------ ------
-
-pub trait IntoCowStr<'a> {
-    fn into_cow_str(self) -> Cow<'a, str>;
-}
-
-impl<'a> IntoCowStr<'a> for String {
-    fn into_cow_str(self) -> Cow<'a, str> {
-        self.into()
-    }
-}
-
-impl<'a> IntoCowStr<'a> for &'a String {
-    fn into_cow_str(self) -> Cow<'a, str> {
-        self.into()
-    }
-}
-
-impl<'a> IntoCowStr<'a> for &'a str {
-    fn into_cow_str(self) -> Cow<'a, str> {
-        self.into()
-    }
-}
-
-impl<'a> IntoCowStr<'a> for Cow<'a, str> {
-    fn into_cow_str(self) -> Cow<'a, str> {
-        self.into()
-    }
-}
-
-macro_rules! make_into_cow_str_impls {
-    ($($type:ty),*) => (
-        $(
-        impl<'a> IntoCowStr<'a> for $type {
-            fn into_cow_str(self) -> Cow<'a, str> {
-                self.to_string().into()
-            }
-        }
-        )*
-    )
-}
-make_into_cow_str_impls!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
 
 // ------ ------
 //  IntoElement

--- a/crates/zoon/src/lib.rs
+++ b/crates/zoon/src/lib.rs
@@ -4,6 +4,9 @@ mod console;
 mod dom;
 pub mod element;
 mod futures_signals_ext;
+mod cow_str;
+
+pub use cow_str::{IntoCowStr, IntoOptionCowStr};
 
 pub use console::log;
 pub use dom::{document, window};

--- a/crates/zoon/src/lib.rs
+++ b/crates/zoon/src/lib.rs
@@ -1,10 +1,10 @@
 pub use wasm_bindgen::{self, prelude::*, JsCast};
 
 mod console;
+mod cow_str;
 mod dom;
 pub mod element;
 mod futures_signals_ext;
-mod cow_str;
 
 pub use cow_str::{IntoCowStr, IntoOptionCowStr};
 

--- a/examples/counters/frontend/src/app/view/element/counter.rs
+++ b/examples/counters/frontend/src/app/view/element/counter.rs
@@ -34,7 +34,7 @@ fn decrement_button() -> Button<button::LabelFlagSet, button::OnPressFlagNotSet>
     Button::new().label("-")
 }
 
-fn value_element(value: impl Signal<Item = impl ToString> + Unpin + 'static) -> impl Element {
+fn value_element<'a>(value: impl Signal<Item = impl IntoCowStr<'a>> + Unpin + 'static) -> impl Element {
     El::new().child(Text::with_signal(value))
 }
 

--- a/examples/js-framework-benchmark/keyed/frontend/src/lib.rs
+++ b/examples/js-framework-benchmark/keyed/frontend/src/lib.rs
@@ -109,31 +109,31 @@ fn remove_row(id: ID) {
 //     View 
 // ------ ------
 
-fn root() -> RawEl {
-    RawEl::new("div")
+fn root() -> RawHtmlEl {
+    RawHtmlEl::new("div")
         .attr("class", "container")
         .children(array::IntoIter::new([
             jumbotron(),
             table(),
-            RawEl::new("span")
+            RawHtmlEl::new("span")
                 .attr("class", "preloadicon glyphicon glyphicon-remove")
                 .attr("aria-hidden", "")
         ]))
 }
 
-fn jumbotron() -> RawEl {
-    RawEl::new("div")
+fn jumbotron() -> RawHtmlEl {
+    RawHtmlEl::new("div")
         .attr("class", "jumbotron")
         .child(
-            RawEl::new("div")
+            RawHtmlEl::new("div")
                 .attr("class", "row")
                 .children(array::IntoIter::new([
-                    RawEl::new("div")
+                    RawHtmlEl::new("div")
                         .attr("class", "col-md-6")
                         .child(
-                            RawEl::new("h1").child("MoonZoon")
+                            RawHtmlEl::new("h1").child("MoonZoon")
                         ),
-                    RawEl::new("div")
+                    RawHtmlEl::new("div")
                         .attr("class", "col-md-6")
                         .child(
                             action_buttons()
@@ -142,8 +142,8 @@ fn jumbotron() -> RawEl {
         )
 }
 
-fn action_buttons() -> RawEl {
-    RawEl::new("div")
+fn action_buttons() -> RawHtmlEl {
+    RawHtmlEl::new("div")
         .attr("class", "row")
         .children(array::IntoIter::new([
             action_button("run", "Create 1,000 rows", || create_rows(1_000)),
@@ -159,11 +159,11 @@ fn action_button(
     id: &'static str, 
     title: &'static str, 
     on_click: fn(),
-) -> RawEl {
-    RawEl::new("div")
+) -> RawHtmlEl {
+    RawHtmlEl::new("div")
         .attr("class", "col-sm-6 smallpad")
         .child(
-            RawEl::new("button")
+            RawHtmlEl::new("button")
                 .attr("id", id)
                 .attr("class", "btn btn-primary btn-block")
                 .attr("type", "button")
@@ -174,12 +174,12 @@ fn action_button(
         )
 }
 
-fn table() -> RawEl {
-    RawEl::new("table")
+fn table() -> RawHtmlEl {
+    RawHtmlEl::new("table")
         .attr("class", "table table-hover table-striped test-data")
         .child_signal(
             rows_exist().map(|rows_exist| rows_exist.then(|| {
-                RawEl::new("tbody")
+                RawHtmlEl::new("tbody")
                     .attr("id", "tbody")
                     .children_signal_vec(
                         rows().signal_vec_cloned().map(row)
@@ -188,9 +188,9 @@ fn table() -> RawEl {
         )
 }
 
-fn row(row: Arc<Row>) -> RawEl {
+fn row(row: Arc<Row>) -> RawHtmlEl {
     let id = row.id;
-    RawEl::new("tr")
+    RawHtmlEl::new("tr")
         .attr_signal(
             "class",
             selected_row().signal_ref(move |selected_id| {
@@ -201,35 +201,35 @@ fn row(row: Arc<Row>) -> RawEl {
             row_id(id),
             row_label(id, row.label.signal_cloned()),
             row_remove_button(id),
-            RawEl::new("td")
+            RawHtmlEl::new("td")
                 .attr("class", "col-md-6")
         ]))
 }
 
-fn row_id(id: ID) -> RawEl {
-    RawEl::new("td")
+fn row_id(id: ID) -> RawHtmlEl {
+    RawHtmlEl::new("td")
         .attr("class", "col-md-1")
         .child(id)
 }
 
-fn row_label(id: ID, label: impl Signal<Item = String> + Unpin + 'static) -> RawEl {
-    RawEl::new("td")
+fn row_label(id: ID, label: impl Signal<Item = String> + Unpin + 'static) -> RawHtmlEl {
+    RawHtmlEl::new("td")
         .attr("class", "col-md-4")
         .child(
-            RawEl::new("a")
+            RawHtmlEl::new("a")
                 .event_handler(move |_: events::Click| select_row(id))
                 .child(Text::with_signal(label))
         )
 }
 
-fn row_remove_button(id: ID) -> RawEl {
-    RawEl::new("td")
+fn row_remove_button(id: ID) -> RawHtmlEl {
+    RawHtmlEl::new("td")
         .attr("class", "col-md-1")
         .child(
-            RawEl::new("a")
+            RawHtmlEl::new("a")
                 .event_handler(move |_: events::Click| remove_row(id))
                 .child(
-                    RawEl::new("span")
+                    RawHtmlEl::new("span")
                         .attr("class", "glyphicon glyphicon-remove remove")
                         .attr("aria-hidden", "true"),
                 )

--- a/examples/svg/Cargo.lock
+++ b/examples/svg/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
 name = "frontend"
 version = "0.1.0"
 dependencies = [
+ "strum",
  "wasm-bindgen-test",
  "zoon",
 ]
@@ -314,6 +315,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -735,6 +745,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +887,12 @@ checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-xid"

--- a/examples/svg/frontend/Cargo.toml
+++ b/examples/svg/frontend/Cargo.toml
@@ -18,6 +18,7 @@ wasm-bindgen-test = "0.3.19"
 [dependencies]
 # zoon = { git = "https://github.com/MartinKavik/MoonZoon" }
 zoon = { path = "../../../crates/zoon" }
+strum = { version = "0.20.0", default-features = false, features = ["derive"] }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ['-Os']

--- a/examples/svg/frontend/src/lib.rs
+++ b/examples/svg/frontend/src/lib.rs
@@ -1,40 +1,25 @@
-use std::fmt;
 use zoon::*;
+use std::{collections::VecDeque, iter::FromIterator};
+use strum::{IntoStaticStr, EnumIter, IntoEnumIterator};
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, IntoStaticStr, EnumIter)]
 enum Color {
     Red,
     Blue,
     Green,
 }
 
-impl fmt::Display for Color {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let c = match self {
-            Self::Red => "#f00",
-            Self::Blue => "#0f0",
-            Self::Green => "#00f",
-        };
-        write!(f, "{}", c)
-    }
-}
-
 #[static_ref]
-fn color() -> &'static Mutable<Color> {
-    Mutable::new(Color::Red)
+fn colors() -> &'static Mutable<VecDeque<Color>> {
+    Mutable::new(VecDeque::from_iter(Color::iter()))
 }
 
-fn color_attr_signal() -> impl Signal<Item = Option<impl ToString>> {
-    color().signal().map(Some)
+fn color_attr_signal() -> impl Signal<Item = &'static str> {
+    colors().signal_ref(|colors| colors[0].into())
 }
 
 fn change_color() {
-    use Color as C;
-    color().update(|c| match c {
-        C::Red => C::Blue,
-        C::Blue => C::Green,
-        C::Green => C::Red,
-    })
+    colors().lock_mut().rotate_left(1);
 }
 
 fn root() -> impl Element {


### PR DESCRIPTION
- Added traits `IntoCowStr` and `IntoOptionCowStr` to eliminate cloning in signals and attrs caused by the removed `impl ToString`.
- Fixed example `js-framework-benchmark` - `RawEl` -> `RawHtmlEl`.
- Refactored example `svg`.

cc @flosse