### PR TITLE
Pass Config via moon::start

### DIFF
--- a/crates/moon/src/lib.rs
+++ b/crates/moon/src/lib.rs
@@ -46,7 +46,7 @@ mod redirect;
 mod sse;
 mod up_msg_request;
 
-use config::Config;
+pub use config::Config;
 use lazy_message_writer::LazyMessageWriter;
 use sse::{ShareableSSE, ShareableSSEMethods, SSE};
 
@@ -108,6 +108,7 @@ trait_set! {
 pub async fn start<'de, FRB, FRBO, UPH, UPHO, UMsg>(
     frontend: FRB,
     up_msg_handler: UPH,
+    config: Config,
     service_config: impl FnOnce(&mut web::ServiceConfig) + Clone + Send + 'static,
 ) -> io::Result<()>
 where
@@ -118,9 +119,6 @@ where
     UMsg: 'static + Deserialize,
 {
     // ------ Init ------
-
-    let config = Config::from_env_vars();
-    println!("Moon config: {:?}", config);
 
     env_logger::builder()
         .filter_level(config.backend_log_level)

--- a/examples/canvas/backend/src/main.rs
+++ b/examples/canvas/backend/src/main.rs
@@ -16,5 +16,7 @@ async fn up_msg_handler(_: UpMsgRequest<()>) {}
 
 #[moon::main]
 async fn main() -> std::io::Result<()> {
-    start(frontend, up_msg_handler, |_| {}).await
+    let config = Config::from_env_vars();
+    println!("Moon config: {:?}", config);
+    start(frontend, up_msg_handler, config, |_| {}).await
 }

--- a/examples/chat/backend/src/main.rs
+++ b/examples/chat/backend/src/main.rs
@@ -23,5 +23,7 @@ async fn up_msg_handler(req: UpMsgRequest<UpMsg>) {
 
 #[moon::main]
 async fn main() -> std::io::Result<()> {
-    start(frontend, up_msg_handler, |_| {}).await
+    let config = Config::from_env_vars();
+    println!("Moon config: {:?}", config);
+    start(frontend, up_msg_handler, config, |_| {}).await
 }

--- a/examples/counter/backend/src/main.rs
+++ b/examples/counter/backend/src/main.rs
@@ -25,5 +25,7 @@ async fn up_msg_handler(_: UpMsgRequest<()>) {}
 
 #[moon::main]
 async fn main() -> std::io::Result<()> {
-    start(frontend, up_msg_handler, |_| {}).await
+    let config = Config::from_env_vars();
+    println!("Moon config: {:?}", config);
+    start(frontend, up_msg_handler, config, |_| {}).await
 }

--- a/examples/counters/backend/src/main.rs
+++ b/examples/counters/backend/src/main.rs
@@ -28,5 +28,7 @@ async fn up_msg_handler(_: UpMsgRequest<()>) {}
 
 #[moon::main]
 async fn main() -> std::io::Result<()> {
-    start(frontend, up_msg_handler, |_| {}).await
+    let config = Config::from_env_vars();
+    println!("Moon config: {:?}", config);
+    start(frontend, up_msg_handler, config, |_| {}).await
 }

--- a/examples/js-framework-benchmark/keyed/backend/src/main.rs
+++ b/examples/js-framework-benchmark/keyed/backend/src/main.rs
@@ -11,5 +11,7 @@ async fn up_msg_handler(_: UpMsgRequest<()>) {}
 
 #[moon::main]
 async fn main() -> std::io::Result<()> {
-    start(frontend, up_msg_handler, |_| {}).await
+    let config = Config::from_env_vars();
+    println!("Moon config: {:?}", config);
+    start(frontend, up_msg_handler, config, |_| {}).await
 }

--- a/examples/svg/backend/src/main.rs
+++ b/examples/svg/backend/src/main.rs
@@ -8,5 +8,7 @@ async fn up_msg_handler(_: UpMsgRequest<()>) {}
 
 #[moon::main]
 async fn main() -> std::io::Result<()> {
-    start(frontend, up_msg_handler, |_| {}).await
+    let config = Config::from_env_vars();
+    println!("Moon config: {:?}", config);
+    start(frontend, up_msg_handler, config, |_| {}).await
 }

--- a/examples/timer/backend/src/main.rs
+++ b/examples/timer/backend/src/main.rs
@@ -16,5 +16,7 @@ async fn up_msg_handler(_: UpMsgRequest<()>) {}
 
 #[moon::main]
 async fn main() -> std::io::Result<()> {
-    start(frontend, up_msg_handler, |_| {}).await
+    let config = Config::from_env_vars();
+    println!("Moon config: {:?}", config);
+    start(frontend, up_msg_handler, config, |_| {}).await
 }

--- a/examples/viewport/backend/src/main.rs
+++ b/examples/viewport/backend/src/main.rs
@@ -16,5 +16,7 @@ async fn up_msg_handler(_: UpMsgRequest<()>) {}
 
 #[moon::main]
 async fn main() -> std::io::Result<()> {
-    start(frontend, up_msg_handler, |_| {}).await
+    let config = Config::from_env_vars();
+    println!("Moon config: {:?}", config);
+    start(frontend, up_msg_handler, config, |_| {}).await
 }


### PR DESCRIPTION
This minor refactor makes it easier to configure the moon backend when it is embedded in other applications while still preserving the ability to configure the examples etc. that are run using the mzoon CLI.

Some older examples (those using the `start!` macro) have not been updated. If the PR is ok, I can make another PR for the template at [MoonZoon/demo](https://github.com/MoonZoon/demo).