### PR TITLE
Make the bound address configurable

### DIFF
--- a/crates/moon/src/config.rs
+++ b/crates/moon/src/config.rs
@@ -1,10 +1,13 @@
 use crate::from_env_vars::FromEnvVars;
 use log::LevelFilter;
 use serde::Deserialize;
+use std::net::IpAddr;
 
 #[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct Config {
+    // ADDRESS
+    pub address: IpAddr,
     // PORT
     pub port: u16,
     // HTTPS
@@ -27,6 +30,7 @@ impl FromEnvVars for Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            address: [0, 0, 0, 0].into(),
             port: 8080,
             https: false,
             compressed_pkg: true,

--- a/crates/moon/src/lib.rs
+++ b/crates/moon/src/lib.rs
@@ -135,7 +135,7 @@ where
     };
     let reload_sse = ReloadSSE(SSE::start());
     let message_sse = MessageSSE(SSE::start());
-    let address = SocketAddr::from(([0, 0, 0, 0], config.port));
+    let address = SocketAddr::from((config.address, config.port));
 
     let redirect_enabled = config.redirect.enabled;
     let redirect = Redirect::new()
@@ -194,7 +194,7 @@ where
     lazy_message_writer.server_is_running(&address, &config)?;
 
     server = if config.redirect.enabled {
-        let address = SocketAddr::from(([0, 0, 0, 0], config.redirect.port));
+        let address = SocketAddr::from((config.address, config.redirect.port));
         lazy_message_writer.redirect_from(&address, &config)?;
         server.bind(address)?
     } else {

--- a/crates/mzoon/src/config.rs
+++ b/crates/mzoon/src/config.rs
@@ -2,10 +2,12 @@ use anyhow::{Context, Error};
 use fehler::throws;
 use log::LevelFilter;
 use serde::Deserialize;
+use std::net::IpAddr;
 use tokio::fs;
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
+    pub address: IpAddr,
     pub port: u16,
     pub https: bool,
     pub cache_busting: bool,

--- a/crates/mzoon/src/set_env_vars.rs
+++ b/crates/mzoon/src/set_env_vars.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use std::env;
 
 pub fn set_env_vars(config: &Config, release: bool) {
+    env::set_var("ADDRESS", config.address.to_string());
     // port = 8443
     env::set_var("PORT", config.port.to_string());
     // https = true

--- a/examples/canvas/MoonZoon.toml
+++ b/examples/canvas/MoonZoon.toml
@@ -1,3 +1,4 @@
+address = "0.0.0.0"
 port = 8080
 # port = 8443
 https = false

--- a/examples/chat/MoonZoon.toml
+++ b/examples/chat/MoonZoon.toml
@@ -1,3 +1,4 @@
+address = "0.0.0.0"
 port = 8080
 # port = 8443
 https = false

--- a/examples/counter/MoonZoon.toml
+++ b/examples/counter/MoonZoon.toml
@@ -1,3 +1,4 @@
+address = "0.0.0.0"
 port = 8080
 # port = 8443
 https = false

--- a/examples/counters/MoonZoon.toml
+++ b/examples/counters/MoonZoon.toml
@@ -1,3 +1,4 @@
+address = "0.0.0.0"
 port = 8080
 # port = 8443
 https = false

--- a/examples/js-framework-benchmark/keyed/MoonZoon.toml
+++ b/examples/js-framework-benchmark/keyed/MoonZoon.toml
@@ -1,3 +1,4 @@
+address = "0.0.0.0"
 port = 8080
 # port = 8443
 https = false

--- a/examples/svg/MoonZoon.toml
+++ b/examples/svg/MoonZoon.toml
@@ -1,3 +1,4 @@
+address = "0.0.0.0"
 port = 8080
 # port = 8443
 https = false

--- a/examples/timer/MoonZoon.toml
+++ b/examples/timer/MoonZoon.toml
@@ -1,3 +1,4 @@
+address = "0.0.0.0"
 port = 8080
 # port = 8443
 https = false

--- a/examples/viewport/MoonZoon.toml
+++ b/examples/viewport/MoonZoon.toml
@@ -1,3 +1,4 @@
+address = "0.0.0.0"
 port = 8080
 # port = 8443
 https = false


### PR DESCRIPTION
Previously the bound address was hardcoded as "0.0.0.0", which is not always desirable. This PR updates the mzoon and moon crates and the examples so that an address can be provided from MoonZoon.toml. The default address is coincides with the previously hard coded address.