### PR TITLE
added WheelEvent

### DIFF
--- a/crates/zoon/Cargo.toml
+++ b/crates/zoon/Cargo.toml
@@ -59,6 +59,7 @@ features = [
   'Request',
   'RequestInit',
   'Storage',
+  'WheelEvent',
 ]
 default-features = false
 

--- a/crates/zoon/src/events_extra.rs
+++ b/crates/zoon/src/events_extra.rs
@@ -78,3 +78,53 @@ macro_rules! make_mouse_event {
 }
 
 make_mouse_event!(MouseOver, "mouseover");
+
+
+make_event!(WheelEvent, "wheel" => web_sys::WheelEvent);
+
+// WheelEvent is a subtype of MouseEvent. It implements what MouseEvent implements plus
+impl WheelEvent {
+    #[inline] pub fn x(&self) -> i32 { self.event.client_x() }
+    #[inline] pub fn y(&self) -> i32 { self.event.client_y() }
+
+    #[inline] pub fn screen_x(&self) -> i32 { self.event.screen_x() }
+    #[inline] pub fn screen_y(&self) -> i32 { self.event.screen_y() }
+
+    #[inline] pub fn ctrl_key(&self) -> bool { self.event.ctrl_key() || self.event.meta_key() }
+    #[inline] pub fn shift_key(&self) -> bool { self.event.shift_key() }
+    #[inline] pub fn alt_key(&self) -> bool { self.event.alt_key() }
+
+    // TODO maybe deprecate these ?
+    #[inline] pub fn mouse_x(&self) -> i32 { self.event.client_x() }
+    #[inline] pub fn mouse_y(&self) -> i32 { self.event.client_y() }
+
+    pub fn button(&self) -> MouseButton {
+        match self.event.button() {
+            0 => MouseButton::Left,
+            1 => MouseButton::Middle,
+            2 => MouseButton::Right,
+            3 => MouseButton::Button4,
+            4 => MouseButton::Button5,
+            _ => unreachable!("Unexpected MouseEvent.button value"),
+        }
+    }
+
+    #[inline] pub fn delta_x(&self)-> f64{self.event.delta_x()}
+    #[inline] pub fn delta_y(&self)-> f64{self.event.delta_y()}
+    #[inline] pub fn delta_z(&self)-> f64{self.event.delta_z()}
+    #[inline] pub fn delta_mode(&self)-> WheelDeltaMode {
+        match self.event.delta_mode(){
+            web_sys::WheelEvent::DOM_DELTA_PIXEL => WheelDeltaMode::Pixel,
+            web_sys::WheelEvent::DOM_DELTA_LINE => WheelDeltaMode::Line,
+            web_sys::WheelEvent::DOM_DELTA_PAGE => WheelDeltaMode::Page,
+            _ => unreachable!("Unexpected WheelEvent.mode value"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum WheelDeltaMode {
+    Pixel,
+    Line,
+    Page
+}


### PR DESCRIPTION
For wheel events this works for me.


There is no `update_raw_el` method on `RawSvgEl´. 
For testing I hooked the event up via 
```
        .event_handler(move |event: zoon::events_extra::WheelEvent| {
            info!(
                "wheel x: {}, y: {}, delta x: {}, delta y: {}, delta z: {}, mode: {:?}, ctrl: {}, button: {:?}",
                event.x(),
                event.y(),
                event.delta_x(),
                event.delta_y(),
                event.delta_z(),
                event.delta_mode(),
                event.ctrl_key(),
                event.button()
            )
        })
```

This results in output like 
```
wheel x: 272, y: 273, delta x: 0, delta y: -108, delta z: 0, mode: Pixel, ctrl: false, button: Left 
wheel x: 272, y: 273, delta x: 9, delta y: 0, delta z: 0, mode: Pixel, ctrl: false, button: Left
```
The first line is shown when I turn my mouse wheel. The second, when I tilt it (usually for sideward scrolling).
