### PR TITLE
Zoon updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "futures-signals"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7c31ebfcb97c87ac64db66a2d4d6ae71b487d5a8ef631c80c3d7e65a772a8c"
+checksum = "402d707a810e5fddfb1d5ff44174ffa96c6c1b136e7019cef5c9ef87c8977592"
 dependencies = [
  "discard",
  "futures-channel",

--- a/crates/zoon/Cargo.toml
+++ b/crates/zoon/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 wasm-bindgen = { version = "0.2.76", default-features = false }
 wasm-bindgen-futures = { version = "0.4.26", default-features = false }
 js-sys = { version = "0.3.53", default-features = false }
-futures-signals = { version = "0.3.22", default-features = false }
+futures-signals = { version = "0.3.23", default-features = false }
 futures-util = { version = "0.3.15", default-features = false }
 dominator = { version = "0.5.22", default-features = false }
 paste = { version = "1.0.5", default-features = false }

--- a/crates/zoon/src/either.rs
+++ b/crates/zoon/src/either.rs
@@ -3,6 +3,7 @@ use std::{
     borrow::Cow,
     pin::Pin,
     task::{Context, Poll},
+    iter,
 };
 
 // ------ IntoEither ------
@@ -35,6 +36,16 @@ impl<L: Element, R: Element> Element for Either<L, R> {
             Either::Left(element) => element.into_raw_element(),
             Either::Right(element) => element.into_raw_element(),
         }
+    }
+}
+
+impl<L: Element, R: Element> IntoIterator for Either<L, R> {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/either.rs
+++ b/crates/zoon/src/either.rs
@@ -1,9 +1,9 @@
 use crate::*;
 use std::{
     borrow::Cow,
+    iter,
     pin::Pin,
     task::{Context, Poll},
-    iter,
 };
 
 // ------ IntoEither ------

--- a/crates/zoon/src/element.rs
+++ b/crates/zoon/src/element.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use std::iter;
 
 // -- modules --
 
@@ -53,7 +54,7 @@ pub use ability::*;
 
 // ------ Element ------
 
-pub trait Element {
+pub trait Element: IntoIterator<Item = Self> {
     fn into_raw_element(self) -> RawElement;
 }
 
@@ -78,6 +79,16 @@ impl IntoDom for RawElement {
 impl Element for RawElement {
     fn into_raw_element(self) -> RawElement {
         self
+    }
+}
+
+impl IntoIterator for RawElement {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/button.rs
+++ b/crates/zoon/src/element/button.rs
@@ -1,5 +1,6 @@
 use crate::{web_sys::HtmlDivElement, *};
 use std::marker::PhantomData;
+use std::iter;
 
 // ------ ------
 //    Element
@@ -50,6 +51,16 @@ impl Button<LabelFlagNotSet, OnPressFlagNotSet> {
 impl<OnPressFlag> Element for Button<LabelFlagSet, OnPressFlag> {
     fn into_raw_element(self) -> RawElement {
         self.raw_el.into()
+    }
+}
+
+impl<LabelFlag, OnPressFlag> IntoIterator for Button<LabelFlag, OnPressFlag> {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/button.rs
+++ b/crates/zoon/src/element/button.rs
@@ -1,6 +1,6 @@
 use crate::{web_sys::HtmlDivElement, *};
-use std::marker::PhantomData;
 use std::iter;
+use std::marker::PhantomData;
 
 // ------ ------
 //    Element

--- a/crates/zoon/src/element/canvas.rs
+++ b/crates/zoon/src/element/canvas.rs
@@ -1,5 +1,6 @@
 use crate::{web_sys::HtmlCanvasElement, *};
 use std::marker::PhantomData;
+use std::iter;
 
 // ------ ------
 //    Element
@@ -24,6 +25,16 @@ impl Canvas<WidthFlagNotSet, HeightFlagNotSet> {
 impl<HeightFlag> Element for Canvas<WidthFlagSet, HeightFlag> {
     fn into_raw_element(self) -> RawElement {
         self.raw_el.into()
+    }
+}
+
+impl<WidthFlag, HeightFlag> IntoIterator for Canvas<WidthFlag, HeightFlag> {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/canvas.rs
+++ b/crates/zoon/src/element/canvas.rs
@@ -1,6 +1,6 @@
 use crate::{web_sys::HtmlCanvasElement, *};
-use std::marker::PhantomData;
 use std::iter;
+use std::marker::PhantomData;
 
 // ------ ------
 //    Element

--- a/crates/zoon/src/element/checkbox.rs
+++ b/crates/zoon/src/element/checkbox.rs
@@ -1,5 +1,6 @@
 use crate::{web_sys::HtmlDivElement, *};
 use std::marker::PhantomData;
+use std::iter;
 
 // ------ ------
 //    Element
@@ -68,6 +69,16 @@ impl<OnChangeFlag, CheckedFlag> Element
 {
     fn into_raw_element(self) -> RawElement {
         self.raw_el.into()
+    }
+}
+
+impl<IdFlag, OnChangeFlag, LabelFlag, IconFlag, CheckedFlag> IntoIterator for Checkbox<IdFlag, OnChangeFlag, LabelFlag, IconFlag, CheckedFlag> {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/checkbox.rs
+++ b/crates/zoon/src/element/checkbox.rs
@@ -1,6 +1,6 @@
 use crate::{web_sys::HtmlDivElement, *};
-use std::marker::PhantomData;
 use std::iter;
+use std::marker::PhantomData;
 
 // ------ ------
 //    Element
@@ -72,7 +72,9 @@ impl<OnChangeFlag, CheckedFlag> Element
     }
 }
 
-impl<IdFlag, OnChangeFlag, LabelFlag, IconFlag, CheckedFlag> IntoIterator for Checkbox<IdFlag, OnChangeFlag, LabelFlag, IconFlag, CheckedFlag> {
+impl<IdFlag, OnChangeFlag, LabelFlag, IconFlag, CheckedFlag> IntoIterator
+    for Checkbox<IdFlag, OnChangeFlag, LabelFlag, IconFlag, CheckedFlag>
+{
     type Item = Self;
     type IntoIter = iter::Once<Self>;
 

--- a/crates/zoon/src/element/column.rs
+++ b/crates/zoon/src/element/column.rs
@@ -1,6 +1,6 @@
 use crate::{web_sys::HtmlElement, *};
-use std::marker::PhantomData;
 use std::iter;
+use std::marker::PhantomData;
 
 // ------ ------
 //   Element

--- a/crates/zoon/src/element/column.rs
+++ b/crates/zoon/src/element/column.rs
@@ -1,5 +1,6 @@
 use crate::{web_sys::HtmlElement, *};
 use std::marker::PhantomData;
+use std::iter;
 
 // ------ ------
 //   Element
@@ -21,6 +22,16 @@ impl Column<EmptyFlagSet> {
 impl Element for Column<EmptyFlagNotSet> {
     fn into_raw_element(self) -> RawElement {
         self.raw_el.into()
+    }
+}
+
+impl<EmptyFlag> IntoIterator for Column<EmptyFlag> {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/el.rs
+++ b/crates/zoon/src/element/el.rs
@@ -1,6 +1,6 @@
 use crate::{web_sys::HtmlElement, *};
-use std::marker::PhantomData;
 use std::iter;
+use std::marker::PhantomData;
 
 // ------ ------
 //   Element

--- a/crates/zoon/src/element/el.rs
+++ b/crates/zoon/src/element/el.rs
@@ -1,5 +1,6 @@
 use crate::{web_sys::HtmlElement, *};
 use std::marker::PhantomData;
+use std::iter;
 
 // ------ ------
 //   Element
@@ -21,6 +22,16 @@ impl El<ChildFlagNotSet> {
 impl<ChildFlag> Element for El<ChildFlag> {
     fn into_raw_element(self) -> RawElement {
         self.raw_el.into()
+    }
+}
+
+impl<ChildFlag> IntoIterator for El<ChildFlag> {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/image.rs
+++ b/crates/zoon/src/element/image.rs
@@ -1,5 +1,6 @@
 use crate::{web_sys::HtmlImageElement, *};
 use std::marker::PhantomData;
+use std::iter;
 
 // ------ ------
 //    Element
@@ -24,6 +25,16 @@ impl Image<UrlFlagNotSet, DescriptionFlagNotSet> {
 impl Element for Image<UrlFlagSet, DescriptionFlagSet> {
     fn into_raw_element(self) -> RawElement {
         self.raw_el.into()
+    }
+}
+
+impl<UrlFlagSet, DescriptionFlagSet> IntoIterator for Image<UrlFlagSet, DescriptionFlagSet> {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/image.rs
+++ b/crates/zoon/src/element/image.rs
@@ -1,6 +1,6 @@
 use crate::{web_sys::HtmlImageElement, *};
-use std::marker::PhantomData;
 use std::iter;
+use std::marker::PhantomData;
 
 // ------ ------
 //    Element

--- a/crates/zoon/src/element/label.rs
+++ b/crates/zoon/src/element/label.rs
@@ -1,5 +1,6 @@
 use crate::{web_sys::HtmlLabelElement, *};
 use std::marker::PhantomData;
+use std::iter;
 
 // ------ ------
 //    Element
@@ -24,6 +25,16 @@ impl Label<LabelFlagNotSet, ForInputFlagNotSet> {
 impl<ForInputFlag> Element for Label<LabelFlagSet, ForInputFlag> {
     fn into_raw_element(self) -> RawElement {
         self.raw_el.into()
+    }
+}
+
+impl<LabelFlag, ForInputFlag> IntoIterator for Label<LabelFlag, ForInputFlag> {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/label.rs
+++ b/crates/zoon/src/element/label.rs
@@ -1,6 +1,6 @@
 use crate::{web_sys::HtmlLabelElement, *};
-use std::marker::PhantomData;
 use std::iter;
+use std::marker::PhantomData;
 
 // ------ ------
 //    Element

--- a/crates/zoon/src/element/link.rs
+++ b/crates/zoon/src/element/link.rs
@@ -1,6 +1,6 @@
 use crate::{web_sys::HtmlAnchorElement, *};
-use std::marker::PhantomData;
 use std::iter;
+use std::marker::PhantomData;
 
 // ------ ------
 //    Element

--- a/crates/zoon/src/element/link.rs
+++ b/crates/zoon/src/element/link.rs
@@ -1,5 +1,6 @@
 use crate::{web_sys::HtmlAnchorElement, *};
 use std::marker::PhantomData;
+use std::iter;
 
 // ------ ------
 //    Element
@@ -47,6 +48,16 @@ impl Link<LabelFlagNotSet, ToFlagNotSet> {
 impl Element for Link<LabelFlagSet, ToFlagSet> {
     fn into_raw_element(self) -> RawElement {
         self.raw_el.into()
+    }
+}
+
+impl<LabelFlag, ToFlag> IntoIterator for Link<LabelFlag, ToFlag> {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/paragraph.rs
+++ b/crates/zoon/src/element/paragraph.rs
@@ -1,5 +1,6 @@
 use crate::{web_sys::HtmlParagraphElement, *};
 use std::marker::PhantomData;
+use std::iter;
 
 // ------ ------
 //   Element
@@ -32,6 +33,16 @@ impl Paragraph<EmptyFlagSet> {
 impl Element for Paragraph<EmptyFlagNotSet> {
     fn into_raw_element(self) -> RawElement {
         self.raw_el.into()
+    }
+}
+
+impl<EmptyFlagSet> IntoIterator for Paragraph<EmptyFlagSet> {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/paragraph.rs
+++ b/crates/zoon/src/element/paragraph.rs
@@ -1,6 +1,6 @@
 use crate::{web_sys::HtmlParagraphElement, *};
-use std::marker::PhantomData;
 use std::iter;
+use std::marker::PhantomData;
 
 // ------ ------
 //   Element
@@ -17,9 +17,7 @@ impl Paragraph<EmptyFlagSet> {
     pub fn new() -> Self {
         run_once!(|| {
             global_styles()
-                .style_group(
-                    StyleGroup::new(".paragraph > *").style_important("display", "inline")
-                )
+                .style_group(StyleGroup::new(".paragraph > *").style_important("display", "inline"))
                 .style_group(StyleGroup::new(".paragraph > .align_left").style("float", "left"))
                 .style_group(StyleGroup::new(".paragraph > .align_right").style("float", "right"));
         });

--- a/crates/zoon/src/element/paragraph.rs
+++ b/crates/zoon/src/element/paragraph.rs
@@ -17,9 +17,7 @@ impl Paragraph<EmptyFlagSet> {
         run_once!(|| {
             global_styles()
                 .style_group(
-                    StyleGroup::new(".paragraph > *")
-                        .style_important("display", "inline-flex")
-                        .style("vertical-align", "middle"),
+                    StyleGroup::new(".paragraph > *").style_important("display", "inline")
                 )
                 .style_group(StyleGroup::new(".paragraph > .align_left").style("float", "left"))
                 .style_group(StyleGroup::new(".paragraph > .align_right").style("float", "right"));

--- a/crates/zoon/src/element/paragraph.rs
+++ b/crates/zoon/src/element/paragraph.rs
@@ -18,7 +18,7 @@ impl Paragraph<EmptyFlagSet> {
             global_styles()
                 .style_group(
                     StyleGroup::new(".paragraph > *")
-                        .style("display", "inline-flex")
+                        .style_important("display", "inline-flex")
                         .style("vertical-align", "middle"),
                 )
                 .style_group(StyleGroup::new(".paragraph > .align_left").style("float", "left"))

--- a/crates/zoon/src/element/raw_el.rs
+++ b/crates/zoon/src/element/raw_el.rs
@@ -151,6 +151,8 @@ pub trait RawEl: Sized {
 
     fn style(self, name: &str, value: &str) -> Self;
 
+    fn style_important(self, name: &str, value: &str) -> Self;
+
     fn style_signal<'a>(
         self,
         name: impl IntoCowStr<'static>,

--- a/crates/zoon/src/element/raw_el/raw_html_el.rs
+++ b/crates/zoon/src/element/raw_el/raw_html_el.rs
@@ -1,6 +1,7 @@
 use super::class_id_generator;
 use crate::css_property_name::CssPropertyName;
 use crate::*;
+use std::iter;
 
 // ------ ------
 //   Element
@@ -41,6 +42,16 @@ impl IntoDom for RawHtmlEl {
 impl Element for RawHtmlEl {
     fn into_raw_element(self) -> RawElement {
         RawElement::El(self)
+    }
+}
+
+impl IntoIterator for RawHtmlEl {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/raw_el/raw_html_el.rs
+++ b/crates/zoon/src/element/raw_el/raw_html_el.rs
@@ -63,6 +63,10 @@ impl RawEl for RawHtmlEl {
         self.update_dom_builder(|dom_builder| dom_builder.style(CssPropertyName::new(name), value))
     }
 
+    fn style_important(self, name: &str, value: &str) -> Self {
+        self.update_dom_builder(|dom_builder| dom_builder.style_important(CssPropertyName::new(name), value))
+    }
+
     fn style_signal<'a>(
         self,
         name: impl IntoCowStr<'static>,

--- a/crates/zoon/src/element/raw_el/raw_html_el.rs
+++ b/crates/zoon/src/element/raw_el/raw_html_el.rs
@@ -75,7 +75,9 @@ impl RawEl for RawHtmlEl {
     }
 
     fn style_important(self, name: &str, value: &str) -> Self {
-        self.update_dom_builder(|dom_builder| dom_builder.style_important(CssPropertyName::new(name), value))
+        self.update_dom_builder(|dom_builder| {
+            dom_builder.style_important(CssPropertyName::new(name), value)
+        })
     }
 
     fn style_signal<'a>(

--- a/crates/zoon/src/element/raw_el/raw_svg_el.rs
+++ b/crates/zoon/src/element/raw_el/raw_svg_el.rs
@@ -63,6 +63,10 @@ impl RawEl for RawSvgEl {
         self.update_dom_builder(|dom_builder| dom_builder.style(CssPropertyName::new(name), value))
     }
 
+    fn style_important(self, name: &str, value: &str) -> Self {
+        self.update_dom_builder(|dom_builder| dom_builder.style_important(CssPropertyName::new(name), value))
+    }
+
     fn style_signal<'a>(
         self,
         name: impl IntoCowStr<'static>,

--- a/crates/zoon/src/element/raw_el/raw_svg_el.rs
+++ b/crates/zoon/src/element/raw_el/raw_svg_el.rs
@@ -75,7 +75,9 @@ impl RawEl for RawSvgEl {
     }
 
     fn style_important(self, name: &str, value: &str) -> Self {
-        self.update_dom_builder(|dom_builder| dom_builder.style_important(CssPropertyName::new(name), value))
+        self.update_dom_builder(|dom_builder| {
+            dom_builder.style_important(CssPropertyName::new(name), value)
+        })
     }
 
     fn style_signal<'a>(

--- a/crates/zoon/src/element/raw_el/raw_svg_el.rs
+++ b/crates/zoon/src/element/raw_el/raw_svg_el.rs
@@ -1,6 +1,7 @@
 use super::class_id_generator;
 use crate::css_property_name::CssPropertyName;
 use crate::*;
+use std::iter;
 
 // ------ ------
 //   Element
@@ -41,6 +42,16 @@ impl IntoDom for RawSvgEl {
 impl Element for RawSvgEl {
     fn into_raw_element(self) -> RawElement {
         RawElement::SvgEl(self)
+    }
+}
+
+impl IntoIterator for RawSvgEl {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/raw_text.rs
+++ b/crates/zoon/src/element/raw_text.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use std::iter;
 
 // ------ ------
 //   Element
@@ -39,5 +40,15 @@ impl IntoDom for RawText {
 impl Element for RawText {
     fn into_raw_element(self) -> RawElement {
         self.into()
+    }
+}
+
+impl IntoIterator for RawText {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }

--- a/crates/zoon/src/element/row.rs
+++ b/crates/zoon/src/element/row.rs
@@ -1,5 +1,6 @@
 use crate::{web_sys::HtmlElement, *};
 use std::marker::PhantomData;
+use std::iter;
 
 // ------ ------
 //   Element
@@ -21,6 +22,16 @@ impl Row<EmptyFlagSet, MultilineFlagNotSet> {
 impl<MultilineFlag> Element for Row<EmptyFlagNotSet, MultilineFlag> {
     fn into_raw_element(self) -> RawElement {
         self.raw_el.into()
+    }
+}
+
+impl<EmptyFlag, MultilineFlag> IntoIterator for Row<EmptyFlag, MultilineFlag> {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/row.rs
+++ b/crates/zoon/src/element/row.rs
@@ -1,6 +1,6 @@
 use crate::{web_sys::HtmlElement, *};
-use std::marker::PhantomData;
 use std::iter;
+use std::marker::PhantomData;
 
 // ------ ------
 //   Element

--- a/crates/zoon/src/element/text.rs
+++ b/crates/zoon/src/element/text.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use std::borrow::Cow;
+use std::iter;
 
 // ------ ------
 //    Element
@@ -28,6 +29,17 @@ impl Text {
 impl Element for Text {
     fn into_raw_element(self) -> RawElement {
         self.raw_text.into()
+    }
+}
+
+
+impl IntoIterator for Text {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/element/text.rs
+++ b/crates/zoon/src/element/text.rs
@@ -32,7 +32,6 @@ impl Element for Text {
     }
 }
 
-
 impl IntoIterator for Text {
     type Item = Self;
     type IntoIter = iter::Once<Self>;

--- a/crates/zoon/src/element/text_input.rs
+++ b/crates/zoon/src/element/text_input.rs
@@ -1,6 +1,6 @@
 use crate::{web_sys::HtmlInputElement, *};
-use std::{borrow::Cow, marker::PhantomData};
 use std::iter;
+use std::{borrow::Cow, marker::PhantomData};
 
 mod input_type;
 pub use input_type::*;
@@ -83,24 +83,18 @@ impl<OnChangeFlag, PlaceholderFlag, TextFlag, InputTypeFlag, ReadOnlyFlag> Eleme
     }
 }
 
-
-impl<
-    IdFlag,
-    OnChangeFlag,
-    PlaceholderFlag,
-    TextFlag,
-    LabelFlag,
-    InputTypeFlag,
-    ReadOnlyFlag,
-> IntoIterator for TextInput<
-    IdFlag,
-    OnChangeFlag,
-    PlaceholderFlag,
-    TextFlag,
-    LabelFlag,
-    InputTypeFlag,
-    ReadOnlyFlag,
-> {
+impl<IdFlag, OnChangeFlag, PlaceholderFlag, TextFlag, LabelFlag, InputTypeFlag, ReadOnlyFlag>
+    IntoIterator
+    for TextInput<
+        IdFlag,
+        OnChangeFlag,
+        PlaceholderFlag,
+        TextFlag,
+        LabelFlag,
+        InputTypeFlag,
+        ReadOnlyFlag,
+    >
+{
     type Item = Self;
     type IntoIter = iter::Once<Self>;
 

--- a/crates/zoon/src/element/text_input.rs
+++ b/crates/zoon/src/element/text_input.rs
@@ -1,5 +1,6 @@
 use crate::{web_sys::HtmlInputElement, *};
 use std::{borrow::Cow, marker::PhantomData};
+use std::iter;
 
 mod input_type;
 pub use input_type::*;
@@ -79,6 +80,33 @@ impl<OnChangeFlag, PlaceholderFlag, TextFlag, InputTypeFlag, ReadOnlyFlag> Eleme
 {
     fn into_raw_element(self) -> RawElement {
         self.raw_el.into()
+    }
+}
+
+
+impl<
+    IdFlag,
+    OnChangeFlag,
+    PlaceholderFlag,
+    TextFlag,
+    LabelFlag,
+    InputTypeFlag,
+    ReadOnlyFlag,
+> IntoIterator for TextInput<
+    IdFlag,
+    OnChangeFlag,
+    PlaceholderFlag,
+    TextFlag,
+    LabelFlag,
+    InputTypeFlag,
+    ReadOnlyFlag,
+> {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/crates/zoon/src/lib.rs
+++ b/crates/zoon/src/lib.rs
@@ -198,9 +198,9 @@ macro_rules! element_vec {
 
 // ------ start_app ------
 
-pub fn start_app<'a, E: Element>(
+pub fn start_app<'a, E: Element, I: IntoIterator<Item = E>>(
     browser_element_id: impl Into<Option<&'a str>>,
-    view_root: impl FnOnce() -> E,
+    view_root: impl FnOnce() -> I,
 ) {
     #[cfg(feature = "panic_hook")]
     #[cfg(debug_assertions)]
@@ -212,5 +212,7 @@ pub fn start_app<'a, E: Element>(
         .map(dominator::get_id)
         .unwrap_or_else(|| dominator::body().unchecked_into());
 
-    dominator::append_dom(&parent, view_root().into_raw_element().into_dom());
+    for element in view_root() {
+        dominator::append_dom(&parent, element.into_raw_element().into_dom());
+    }
 }

--- a/crates/zoon/src/style.rs
+++ b/crates/zoon/src/style.rs
@@ -24,7 +24,7 @@ mod clip;
 pub use clip::Clip;
 
 mod font;
-pub use font::{Font, FontFamily, FontWeight, NamedWeight};
+pub use font::{Font, FontFamily, FontWeight};
 
 mod height;
 pub use height::Height;

--- a/crates/zoon/src/style.rs
+++ b/crates/zoon/src/style.rs
@@ -24,7 +24,7 @@ mod clip;
 pub use clip::Clip;
 
 mod font;
-pub use font::{Font, FontFamily, FontWeight, FontLine};
+pub use font::{Font, FontFamily, FontLine, FontWeight};
 
 mod height;
 pub use height::Height;
@@ -67,17 +67,23 @@ pub struct StaticCSSProps<'a>(BTreeMap<&'a str, CssPropValue<'a>>);
 
 impl<'a> StaticCSSProps<'a> {
     pub fn insert(&mut self, name: &'a str, value: impl IntoCowStr<'a>) {
-        self.0.insert(name, CssPropValue {
-            value: value.into_cow_str(),
-            important: false
-        });
+        self.0.insert(
+            name,
+            CssPropValue {
+                value: value.into_cow_str(),
+                important: false,
+            },
+        );
     }
 
     pub fn insert_important(&mut self, name: &'a str, value: impl IntoCowStr<'a>) {
-        self.0.insert(name, CssPropValue {
-            value: value.into_cow_str(),
-            important: true
-        });
+        self.0.insert(
+            name,
+            CssPropValue {
+                value: value.into_cow_str(),
+                important: true,
+            },
+        );
     }
 }
 
@@ -91,7 +97,7 @@ impl<'a> IntoIterator for StaticCSSProps<'a> {
 }
 
 impl<'a> Extend<(&'a str, CssPropValue<'a>)> for StaticCSSProps<'a> {
-    fn extend<T: IntoIterator<Item=(&'a str, CssPropValue<'a>)>>(&mut self, iter: T) {
+    fn extend<T: IntoIterator<Item = (&'a str, CssPropValue<'a>)>>(&mut self, iter: T) {
         self.0.extend(iter);
     }
 }
@@ -259,7 +265,12 @@ impl GlobalStyles {
         drop(ids_lock);
 
         for (name, css_prop_value) in group.static_css_props {
-            set_css_property(&declaration, name, &css_prop_value.value, css_prop_value.important);
+            set_css_property(
+                &declaration,
+                name,
+                &css_prop_value.value,
+                css_prop_value.important,
+            );
         }
 
         let declaration = Arc::new(SendWrapper::new(declaration));
@@ -293,7 +304,9 @@ impl GlobalStyles {
 
 fn set_css_property(declaration: &CssStyleDeclaration, name: &str, value: &str, important: bool) {
     let priority = if important { "important" } else { "" };
-    declaration.set_property_with_priority(name, value, priority).unwrap_throw();
+    declaration
+        .set_property_with_priority(name, value, priority)
+        .unwrap_throw();
     if not(declaration
         .get_property_value(name)
         .unwrap_throw()

--- a/crates/zoon/src/style.rs
+++ b/crates/zoon/src/style.rs
@@ -24,7 +24,7 @@ mod clip;
 pub use clip::Clip;
 
 mod font;
-pub use font::{Font, FontFamily, FontWeight};
+pub use font::{Font, FontFamily, FontWeight, FontLine};
 
 mod height;
 pub use height::Height;
@@ -87,6 +87,12 @@ impl<'a> IntoIterator for StaticCSSProps<'a> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+impl<'a> Extend<(&'a str, CssPropValue<'a>)> for StaticCSSProps<'a> {
+    fn extend<T: IntoIterator<Item=(&'a str, CssPropValue<'a>)>>(&mut self, iter: T) {
+        self.0.extend(iter);
     }
 }
 

--- a/crates/zoon/src/style/background.rs
+++ b/crates/zoon/src/style/background.rs
@@ -27,7 +27,7 @@ impl<'a> Background<'a> {
 
     pub fn url(mut self, url: impl IntoCowStr<'a>) -> Self {
         let url = ["url(", &url.into_cow_str(), ")"].concat();
-        self.static_css_props.insert("background-image", url.into());
+        self.static_css_props.insert("background-image", url);
         self
     }
 
@@ -49,16 +49,24 @@ impl<'a> Style<'a> for Background<'a> {
         style_group: Option<StyleGroup<'a>>,
     ) -> (E, Option<StyleGroup<'a>>) {
         if let Some(mut style_group) = style_group {
-            for (name, value) in self.static_css_props {
-                style_group = style_group.style(name, value);
+            for (name, css_prop_value) in self.static_css_props {
+                style_group = if css_prop_value.important {
+                    style_group.style(name, css_prop_value.value)
+                } else {
+                    style_group.style_important(name, css_prop_value.value)
+                };
             }
             for (name, value) in self.dynamic_css_props {
                 style_group = style_group.style_signal(name, value);
             }
             return (raw_el, Some(style_group));
         }
-        for (name, value) in self.static_css_props {
-            raw_el = raw_el.style(name, &value);
+        for (name, css_prop_value) in self.static_css_props {
+            raw_el = if css_prop_value.important {
+                raw_el.style_important(name, &css_prop_value.value)
+            } else {
+                raw_el.style(name, &css_prop_value.value)
+            };
         }
         for (name, value) in self.dynamic_css_props {
             raw_el = raw_el.style_signal(name, value);

--- a/crates/zoon/src/style/borders.rs
+++ b/crates/zoon/src/style/borders.rs
@@ -135,16 +135,24 @@ impl<'a> Style<'a> for Borders<'a> {
             raw_el = raw_el.after_remove(move |_| drop(task_handles))
         }
         if let Some(mut style_group) = style_group {
-            for (name, value) in self.static_css_props {
-                style_group = style_group.style(name, value);
+            for (name, css_prop_value) in self.static_css_props {
+                style_group = if css_prop_value.important {
+                    style_group.style(name, css_prop_value.value)
+                } else {
+                    style_group.style_important(name, css_prop_value.value)
+                };
             }
             for (name, value) in self.dynamic_css_props {
                 style_group = style_group.style_signal(name, value);
             }
             return (raw_el, Some(style_group));
         }
-        for (name, value) in self.static_css_props {
-            raw_el = raw_el.style(name, &value);
+        for (name, css_prop_value) in self.static_css_props {
+            raw_el = if css_prop_value.important {
+                raw_el.style_important(name, &css_prop_value.value)
+            } else {
+                raw_el.style(name, &css_prop_value.value)
+            };
         }
         for (name, value) in self.dynamic_css_props {
             raw_el = raw_el.style_signal(name, value);

--- a/crates/zoon/src/style/clip.rs
+++ b/crates/zoon/src/style/clip.rs
@@ -8,20 +8,20 @@ pub struct Clip<'a> {
 impl<'a> Clip<'a> {
     pub fn both() -> Self {
         let mut this = Self::default();
-        this.static_css_props.insert("overflow-x", "hidden".into());
-        this.static_css_props.insert("overflow-y", "hidden".into());
+        this.static_css_props.insert("overflow-x", "hidden");
+        this.static_css_props.insert("overflow-y", "hidden");
         this
     }
 
     pub fn x() -> Self {
         let mut this = Self::default();
-        this.static_css_props.insert("overflow-x", "hidden".into());
+        this.static_css_props.insert("overflow-x", "hidden");
         this
     }
 
     pub fn y() -> Self {
         let mut this = Self::default();
-        this.static_css_props.insert("overflow-y", "hidden".into());
+        this.static_css_props.insert("overflow-y", "hidden");
         this
     }
 }
@@ -33,13 +33,21 @@ impl<'a> Style<'a> for Clip<'a> {
         style_group: Option<StyleGroup<'a>>,
     ) -> (E, Option<StyleGroup<'a>>) {
         if let Some(mut style_group) = style_group {
-            for (name, value) in self.static_css_props {
-                style_group = style_group.style(name, value);
+            for (name, css_prop_value) in self.static_css_props {
+                style_group = if css_prop_value.important {
+                    style_group.style(name, css_prop_value.value)
+                } else {
+                    style_group.style_important(name, css_prop_value.value)
+                };
             }
             return (raw_el, Some(style_group));
         }
-        for (name, value) in self.static_css_props {
-            raw_el = raw_el.style(name, &value);
+        for (name, css_prop_value) in self.static_css_props {
+            raw_el = if css_prop_value.important {
+                raw_el.style_important(name, &css_prop_value.value)
+            } else {
+                raw_el.style(name, &css_prop_value.value)
+            };
         }
         (raw_el, None)
     }

--- a/crates/zoon/src/style/font.rs
+++ b/crates/zoon/src/style/font.rs
@@ -7,6 +7,9 @@ pub use font_weight::FontWeight;
 mod font_family;
 pub use font_family::FontFamily;
 
+mod font_line;
+pub use font_line::FontLine;
+
 #[derive(Default)]
 pub struct Font<'a> {
     static_css_props: StaticCSSProps<'a>,
@@ -67,35 +70,6 @@ impl<'a> Font<'a> {
         self
     }
 
-    pub fn underline(mut self) -> Self {
-        self.static_css_props
-            .insert("text-decoration", "underline");
-        self
-    }
-
-    pub fn underline_signal(
-        mut self,
-        underline: impl Signal<Item = bool> + Unpin + 'static,
-    ) -> Self {
-        let underline = underline.map_bool(|| "underline", || "none");
-        self.dynamic_css_props
-            .insert("text-decoration".into(), box_css_signal(underline));
-        self
-    }
-
-    pub fn strike(mut self) -> Self {
-        self.static_css_props
-            .insert("text-decoration", "line-through");
-        self
-    }
-
-    pub fn strike_signal(mut self, strike: impl Signal<Item = bool> + Unpin + 'static) -> Self {
-        let strike = strike.map_bool(|| "line-through", || "none");
-        self.dynamic_css_props
-            .insert("text-decoration".into(), box_css_signal(strike));
-        self
-    }
-
     pub fn center(mut self) -> Self {
         self.static_css_props.insert("text-align", "center");
         self
@@ -109,6 +83,12 @@ impl<'a> Font<'a> {
             .join(", ");
         self.static_css_props
             .insert("font-family", font_family);
+        self
+    }
+
+    pub fn line(mut self, line: FontLine<'a>) -> Self {
+        self.static_css_props.extend(line.static_css_props.into_iter());
+        self.dynamic_css_props.extend(line.dynamic_css_props.into_iter());
         self
     }
 }

--- a/crates/zoon/src/style/font.rs
+++ b/crates/zoon/src/style/font.rs
@@ -81,14 +81,15 @@ impl<'a> Font<'a> {
             .map(|family| family.into_cow_str())
             .collect::<Cow<_>>()
             .join(", ");
-        self.static_css_props
-            .insert("font-family", font_family);
+        self.static_css_props.insert("font-family", font_family);
         self
     }
 
     pub fn line(mut self, line: FontLine<'a>) -> Self {
-        self.static_css_props.extend(line.static_css_props.into_iter());
-        self.dynamic_css_props.extend(line.dynamic_css_props.into_iter());
+        self.static_css_props
+            .extend(line.static_css_props.into_iter());
+        self.dynamic_css_props
+            .extend(line.dynamic_css_props.into_iter());
         self
     }
 }

--- a/crates/zoon/src/style/font.rs
+++ b/crates/zoon/src/style/font.rs
@@ -48,18 +48,18 @@ impl<'a> Font<'a> {
     }
 
     pub fn italic(mut self) -> Self {
-        self.static_css_props.insert("font-style", "italic".into());
+        self.static_css_props.insert("font-style", "italic");
         self
     }
 
     pub fn no_wrap(mut self) -> Self {
-        self.static_css_props.insert("white-space", "nowrap".into());
+        self.static_css_props.insert("white-space", "nowrap");
         self
     }
 
     pub fn underline(mut self) -> Self {
         self.static_css_props
-            .insert("text-decoration", "underline".into());
+            .insert("text-decoration", "underline");
         self
     }
 
@@ -75,7 +75,7 @@ impl<'a> Font<'a> {
 
     pub fn strike(mut self) -> Self {
         self.static_css_props
-            .insert("text-decoration", "line-through".into());
+            .insert("text-decoration", "line-through");
         self
     }
 
@@ -87,7 +87,7 @@ impl<'a> Font<'a> {
     }
 
     pub fn center(mut self) -> Self {
-        self.static_css_props.insert("text-align", "center".into());
+        self.static_css_props.insert("text-align", "center");
         self
     }
 
@@ -98,7 +98,7 @@ impl<'a> Font<'a> {
             .collect::<Cow<_>>()
             .join(", ");
         self.static_css_props
-            .insert("font-family", font_family.into());
+            .insert("font-family", font_family);
         self
     }
 }
@@ -110,16 +110,24 @@ impl<'a> Style<'a> for Font<'a> {
         style_group: Option<StyleGroup<'a>>,
     ) -> (E, Option<StyleGroup<'a>>) {
         if let Some(mut style_group) = style_group {
-            for (name, value) in self.static_css_props {
-                style_group = style_group.style(name, value);
+            for (name, css_prop_value) in self.static_css_props {
+                style_group = if css_prop_value.important {
+                    style_group.style(name, css_prop_value.value)
+                } else {
+                    style_group.style_important(name, css_prop_value.value)
+                };
             }
             for (name, value) in self.dynamic_css_props {
                 style_group = style_group.style_signal(name, value);
             }
             return (raw_el, Some(style_group));
         }
-        for (name, value) in self.static_css_props {
-            raw_el = raw_el.style(name, &value);
+        for (name, css_prop_value) in self.static_css_props {
+            raw_el = if css_prop_value.important {
+                raw_el.style_important(name, &css_prop_value.value)
+            } else {
+                raw_el.style(name, &css_prop_value.value)
+            };
         }
         for (name, value) in self.dynamic_css_props {
             raw_el = raw_el.style_signal(name, value);

--- a/crates/zoon/src/style/font.rs
+++ b/crates/zoon/src/style/font.rs
@@ -2,7 +2,7 @@ use crate::*;
 use std::borrow::Cow;
 
 mod font_weight;
-pub use font_weight::{FontWeight, NamedWeight};
+pub use font_weight::FontWeight;
 
 mod font_family;
 pub use font_family::FontFamily;
@@ -14,9 +14,9 @@ pub struct Font<'a> {
 }
 
 impl<'a> Font<'a> {
-    pub fn weight(mut self, weight: impl FontWeight<'a>) -> Self {
+    pub fn weight(mut self, weight: FontWeight) -> Self {
         self.static_css_props
-            .insert("font-weight", weight.into_cow_str());
+            .insert("font-weight", weight.number().into_cow_str());
         self
     }
 

--- a/crates/zoon/src/style/font.rs
+++ b/crates/zoon/src/style/font.rs
@@ -42,6 +42,16 @@ impl<'a> Font<'a> {
         self
     }
 
+    pub fn size_signal(
+        mut self,
+        size: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
+    ) -> Self {
+        let size = size.map(|size| size.into().map(px));
+        self.dynamic_css_props
+            .insert("font-size".into(), box_css_signal(size));
+        self
+    }
+
     pub fn line_height(mut self, line_height: u32) -> Self {
         self.static_css_props.insert("line-height", px(line_height));
         self

--- a/crates/zoon/src/style/font/font_line.rs
+++ b/crates/zoon/src/style/font/font_line.rs
@@ -42,7 +42,8 @@ impl FontLine<'_> {
 
     pub fn color(mut self, color: impl Into<Option<HSLuv>>) -> Self {
         if let Some(color) = color.into() {
-            self.static_css_props.insert("text-decoration-color", color.into_cow_str());
+            self.static_css_props
+                .insert("text-decoration-color", color.into_cow_str());
         }
         self
     }

--- a/crates/zoon/src/style/font/font_line.rs
+++ b/crates/zoon/src/style/font/font_line.rs
@@ -1,0 +1,105 @@
+use crate::*;
+
+#[derive(Default)]
+pub struct FontLine<'a> {
+    pub(crate) static_css_props: StaticCSSProps<'a>,
+    pub(crate) dynamic_css_props: DynamicCSSProps,
+}
+
+impl FontLine<'_> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn underline(mut self) -> Self {
+        self.static_css_props
+            .insert("text-decoration-line", "underline");
+        self
+    }
+
+    pub fn underline_signal(
+        mut self,
+        underline: impl Signal<Item = bool> + Unpin + 'static,
+    ) -> Self {
+        let underline = underline.map_bool(|| "underline", || "none");
+        self.dynamic_css_props
+            .insert("text-decoration-line".into(), box_css_signal(underline));
+        self
+    }
+
+    pub fn strike(mut self) -> Self {
+        self.static_css_props
+            .insert("text-decoration-line", "line-through");
+        self
+    }
+
+    pub fn strike_signal(mut self, strike: impl Signal<Item = bool> + Unpin + 'static) -> Self {
+        let strike = strike.map_bool(|| "line-through", || "none");
+        self.dynamic_css_props
+            .insert("text-decoration-line".into(), box_css_signal(strike));
+        self
+    }
+
+    pub fn color(mut self, color: impl Into<Option<HSLuv>>) -> Self {
+        if let Some(color) = color.into() {
+            self.static_css_props.insert("text-decoration-color", color.into_cow_str());
+        }
+        self
+    }
+
+    pub fn color_signal(
+        mut self,
+        color: impl Signal<Item = impl Into<Option<HSLuv>>> + Unpin + 'static,
+    ) -> Self {
+        let color = color.map(|color| color.into().map(|color| color.into_cow_str()));
+        self.dynamic_css_props
+            .insert("text-decoration-color".into(), box_css_signal(color));
+        self
+    }
+
+    pub fn width(mut self, width: u32) -> Self {
+        self.static_css_props
+            .insert("text-decoration-thickness", px(width));
+        self
+    }
+
+    pub fn width_signal(
+        mut self,
+        width: impl Signal<Item = impl Into<Option<HSLuv>>> + Unpin + 'static,
+    ) -> Self {
+        let width = width.map(|width| width.into().map(|width| px(width)));
+        self.dynamic_css_props
+            .insert("text-decoration-thickness".into(), box_css_signal(width));
+        self
+    }
+
+    pub fn solid(mut self) -> Self {
+        self.static_css_props
+            .insert("text-decoration-style", "solid");
+        self
+    }
+
+    pub fn double(mut self) -> Self {
+        self.static_css_props
+            .insert("text-decoration-style", "double");
+        self
+    }
+
+    pub fn dotted(mut self) -> Self {
+        self.static_css_props
+            .insert("text-decoration-style", "dotted");
+        self
+    }
+
+    pub fn dashed(mut self) -> Self {
+        self.static_css_props
+            .insert("text-decoration-style", "dashed");
+        self
+    }
+
+    pub fn wavy(mut self) -> Self {
+        self.static_css_props
+            .insert("text-decoration-style", "wavy");
+        self
+    }
+}

--- a/crates/zoon/src/style/font/font_weight.rs
+++ b/crates/zoon/src/style/font/font_weight.rs
@@ -1,14 +1,7 @@
-use crate::*;
-use std::borrow::Cow;
-
 // ------ FontWeight ------
 
-pub trait FontWeight<'a>: IntoCowStr<'a> {}
-
-// ------ NamedWeight ------
-
 #[derive(Clone, Copy, PartialEq, PartialOrd)]
-pub enum NamedWeight {
+pub enum FontWeight {
     Heavy,
     ExtraBold,
     Bold,
@@ -18,27 +11,22 @@ pub enum NamedWeight {
     Light,
     ExtraLight,
     Hairline,
+    Number(u32),
 }
 
-impl FontWeight<'_> for NamedWeight {}
-
-impl<'a> IntoCowStr<'a> for NamedWeight {
-    fn into_cow_str(self) -> Cow<'a, str> {
+impl FontWeight {
+    pub fn number(&self) -> u32 {
         match self {
-            NamedWeight::Heavy => "900",
-            NamedWeight::ExtraBold => "800",
-            NamedWeight::Bold => "700",
-            NamedWeight::SemiBold => "600",
-            NamedWeight::Medium => "500",
-            NamedWeight::Regular => "400",
-            NamedWeight::Light => "300",
-            NamedWeight::ExtraLight => "200",
-            NamedWeight::Hairline => "100",
+            Self::Heavy => 900,
+            Self::ExtraBold => 800,
+            Self::Bold => 700,
+            Self::SemiBold => 600,
+            Self::Medium => 500,
+            Self::Regular => 400,
+            Self::Light => 300,
+            Self::ExtraLight => 200,
+            Self::Hairline => 100,
+            Self::Number(number) => *number,
         }
-        .into()
-    }
-
-    fn take_into_cow_str(&mut self) -> Cow<'a, str> {
-        self.into_cow_str()
     }
 }

--- a/crates/zoon/src/style/height.rs
+++ b/crates/zoon/src/style/height.rs
@@ -21,7 +21,8 @@ impl<'a> Height<'a> {
     ) -> Self {
         let mut this = Self::default();
         let height = height.map(|height| height.into().map(px));
-        this.dynamic_css_props.insert("height".into(), box_css_signal(height));
+        this.dynamic_css_props
+            .insert("height".into(), box_css_signal(height));
         this.static_css_classes.insert("exact_height".into());
         this.static_css_classes.remove("fill_height".into());
         this

--- a/crates/zoon/src/style/height.rs
+++ b/crates/zoon/src/style/height.rs
@@ -17,7 +17,7 @@ impl<'a> Height<'a> {
 
     pub fn fill() -> Self {
         let mut this = Self::default();
-        this.static_css_props.insert("height", "100%".into());
+        this.static_css_props.insert("height", "100%");
         this.static_css_classes.insert("fill_height".into());
         this.static_css_classes.remove("exact_height".into());
         this
@@ -25,14 +25,14 @@ impl<'a> Height<'a> {
 
     pub fn screen() -> Self {
         let mut this = Self::default();
-        this.static_css_props.insert("height", "100vh".into());
+        this.static_css_props.insert("height", "100vh");
         this.static_css_classes.insert("exact_height".into());
         this.static_css_classes.remove("fill_height".into());
         this
     }
 
     pub fn min_screen(mut self) -> Self {
-        self.static_css_props.insert("min-height", "100vh".into());
+        self.static_css_props.insert("min-height", "100vh");
         self
     }
 
@@ -49,16 +49,24 @@ impl<'a> Style<'a> for Height<'a> {
         style_group: Option<StyleGroup<'a>>,
     ) -> (E, Option<StyleGroup<'a>>) {
         if let Some(mut style_group) = style_group {
-            for (name, value) in self.static_css_props {
-                style_group = style_group.style(name, value);
+            for (name, css_prop_value) in self.static_css_props {
+                style_group = if css_prop_value.important {
+                    style_group.style(name, css_prop_value.value)
+                } else {
+                    style_group.style_important(name, css_prop_value.value)
+                };
             }
             for class in self.static_css_classes {
                 raw_el = raw_el.class(&class);
             }
             return (raw_el, Some(style_group));
         }
-        for (name, value) in self.static_css_props {
-            raw_el = raw_el.style(name, &value);
+        for (name, css_prop_value) in self.static_css_props {
+            raw_el = if css_prop_value.important {
+                raw_el.style_important(name, &css_prop_value.value)
+            } else {
+                raw_el.style(name, &css_prop_value.value)
+            };
         }
         for class in self.static_css_classes {
             raw_el = raw_el.class(&class);

--- a/crates/zoon/src/style/layer_index.rs
+++ b/crates/zoon/src/style/layer_index.rs
@@ -21,13 +21,21 @@ impl<'a> Style<'a> for LayerIndex<'a> {
         style_group: Option<StyleGroup<'a>>,
     ) -> (E, Option<StyleGroup<'a>>) {
         if let Some(mut style_group) = style_group {
-            for (name, value) in self.static_css_props {
-                style_group = style_group.style(name, value);
+            for (name, css_prop_value) in self.static_css_props {
+                style_group = if css_prop_value.important {
+                    style_group.style(name, css_prop_value.value)
+                } else {
+                    style_group.style_important(name, css_prop_value.value)
+                };
             }
             return (raw_el, Some(style_group));
         }
-        for (name, value) in self.static_css_props {
-            raw_el = raw_el.style(name, &value);
+        for (name, css_prop_value) in self.static_css_props {
+            raw_el = if css_prop_value.important {
+                raw_el.style_important(name, &css_prop_value.value)
+            } else {
+                raw_el.style(name, &css_prop_value.value)
+            };
         }
         (raw_el, None)
     }

--- a/crates/zoon/src/style/padding.rs
+++ b/crates/zoon/src/style/padding.rs
@@ -46,13 +46,21 @@ impl<'a> Style<'a> for Padding<'a> {
         style_group: Option<StyleGroup<'a>>,
     ) -> (E, Option<StyleGroup<'a>>) {
         if let Some(mut style_group) = style_group {
-            for (name, value) in self.static_css_props {
-                style_group = style_group.style(name, value);
+            for (name, css_prop_value) in self.static_css_props {
+                style_group = if css_prop_value.important {
+                    style_group.style(name, css_prop_value.value)
+                } else {
+                    style_group.style_important(name, css_prop_value.value)
+                };
             }
             return (raw_el, Some(style_group));
         }
-        for (name, value) in self.static_css_props {
-            raw_el = raw_el.style(name, &value);
+        for (name, css_prop_value) in self.static_css_props {
+            raw_el = if css_prop_value.important {
+                raw_el.style_important(name, &css_prop_value.value)
+            } else {
+                raw_el.style(name, &css_prop_value.value)
+            };
         }
         (raw_el, None)
     }

--- a/crates/zoon/src/style/padding.rs
+++ b/crates/zoon/src/style/padding.rs
@@ -11,9 +11,7 @@ impl<'a> Padding<'a> {
         Self::default().x(padding).y(padding)
     }
 
-    pub fn all_signal(
-        all: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
-    ) -> Self {
+    pub fn all_signal(all: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static) -> Self {
         let this = Self::default();
         let all = Broadcaster::new(all.map(|all| all.into()));
         this.x_signal(all.signal()).y_signal(all.signal())
@@ -23,10 +21,7 @@ impl<'a> Padding<'a> {
         self.left(x).right(x)
     }
 
-    pub fn x_signal(
-        self,
-        x: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
-    ) -> Self {
+    pub fn x_signal(self, x: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static) -> Self {
         let x = Broadcaster::new(x.map(|x| x.into()));
         self.left_signal(x.signal()).right_signal(x.signal())
     }
@@ -35,10 +30,7 @@ impl<'a> Padding<'a> {
         self.top(y).bottom(y)
     }
 
-    pub fn y_signal(
-        self,
-        y: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
-    ) -> Self {
+    pub fn y_signal(self, y: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static) -> Self {
         let y = Broadcaster::new(y.map(|y| y.into()));
         self.top_signal(y.signal()).bottom_signal(y.signal())
     }
@@ -53,7 +45,8 @@ impl<'a> Padding<'a> {
         top: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
     ) -> Self {
         let top = top.map(|top| top.into().map(px));
-        self.dynamic_css_props.insert("padding-top".into(), box_css_signal(top));
+        self.dynamic_css_props
+            .insert("padding-top".into(), box_css_signal(top));
         self
     }
 
@@ -67,7 +60,8 @@ impl<'a> Padding<'a> {
         right: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
     ) -> Self {
         let right = right.map(|right| right.into().map(px));
-        self.dynamic_css_props.insert("padding-right".into(), box_css_signal(right));
+        self.dynamic_css_props
+            .insert("padding-right".into(), box_css_signal(right));
         self
     }
 
@@ -81,7 +75,8 @@ impl<'a> Padding<'a> {
         bottom: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
     ) -> Self {
         let bottom = bottom.map(|bottom| bottom.into().map(px));
-        self.dynamic_css_props.insert("padding-bottom".into(), box_css_signal(bottom));
+        self.dynamic_css_props
+            .insert("padding-bottom".into(), box_css_signal(bottom));
         self
     }
 
@@ -95,7 +90,8 @@ impl<'a> Padding<'a> {
         left: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
     ) -> Self {
         let left = left.map(|left| left.into().map(px));
-        self.dynamic_css_props.insert("padding-left".into(), box_css_signal(left));
+        self.dynamic_css_props
+            .insert("padding-left".into(), box_css_signal(left));
         self
     }
 }

--- a/crates/zoon/src/style/padding.rs
+++ b/crates/zoon/src/style/padding.rs
@@ -3,6 +3,7 @@ use crate::*;
 #[derive(Default)]
 pub struct Padding<'a> {
     static_css_props: StaticCSSProps<'a>,
+    dynamic_css_props: DynamicCSSProps,
 }
 
 impl<'a> Padding<'a> {
@@ -10,16 +11,49 @@ impl<'a> Padding<'a> {
         Self::default().x(padding).y(padding)
     }
 
+    pub fn all_signal(
+        all: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
+    ) -> Self {
+        let this = Self::default();
+        let all = Broadcaster::new(all.map(|all| all.into()));
+        this.x_signal(all.signal()).y_signal(all.signal())
+    }
+
     pub fn x(self, x: u32) -> Self {
         self.left(x).right(x)
+    }
+
+    pub fn x_signal(
+        self,
+        x: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
+    ) -> Self {
+        let x = Broadcaster::new(x.map(|x| x.into()));
+        self.left_signal(x.signal()).right_signal(x.signal())
     }
 
     pub fn y(self, y: u32) -> Self {
         self.top(y).bottom(y)
     }
 
+    pub fn y_signal(
+        self,
+        y: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
+    ) -> Self {
+        let y = Broadcaster::new(y.map(|y| y.into()));
+        self.top_signal(y.signal()).bottom_signal(y.signal())
+    }
+
     pub fn top(mut self, top: u32) -> Self {
         self.static_css_props.insert("padding-top", px(top));
+        self
+    }
+
+    pub fn top_signal(
+        mut self,
+        top: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
+    ) -> Self {
+        let top = top.map(|top| top.into().map(px));
+        self.dynamic_css_props.insert("padding-top".into(), box_css_signal(top));
         self
     }
 
@@ -28,13 +62,40 @@ impl<'a> Padding<'a> {
         self
     }
 
+    pub fn right_signal(
+        mut self,
+        right: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
+    ) -> Self {
+        let right = right.map(|right| right.into().map(px));
+        self.dynamic_css_props.insert("padding-right".into(), box_css_signal(right));
+        self
+    }
+
     pub fn bottom(mut self, bottom: u32) -> Self {
         self.static_css_props.insert("padding-bottom", px(bottom));
         self
     }
 
+    pub fn bottom_signal(
+        mut self,
+        bottom: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
+    ) -> Self {
+        let bottom = bottom.map(|bottom| bottom.into().map(px));
+        self.dynamic_css_props.insert("padding-bottom".into(), box_css_signal(bottom));
+        self
+    }
+
     pub fn left(mut self, left: u32) -> Self {
         self.static_css_props.insert("padding-left", px(left));
+        self
+    }
+
+    pub fn left_signal(
+        mut self,
+        left: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
+    ) -> Self {
+        let left = left.map(|left| left.into().map(px));
+        self.dynamic_css_props.insert("padding-left".into(), box_css_signal(left));
         self
     }
 }
@@ -53,6 +114,9 @@ impl<'a> Style<'a> for Padding<'a> {
                     style_group.style_important(name, css_prop_value.value)
                 };
             }
+            for (name, value) in self.dynamic_css_props {
+                style_group = style_group.style_signal(name, value);
+            }
             return (raw_el, Some(style_group));
         }
         for (name, css_prop_value) in self.static_css_props {
@@ -61,6 +125,9 @@ impl<'a> Style<'a> for Padding<'a> {
             } else {
                 raw_el.style(name, &css_prop_value.value)
             };
+        }
+        for (name, value) in self.dynamic_css_props {
+            raw_el = raw_el.style_signal(name, value);
         }
         (raw_el, None)
     }

--- a/crates/zoon/src/style/scrollbars.rs
+++ b/crates/zoon/src/style/scrollbars.rs
@@ -8,23 +8,23 @@ pub struct Scrollbars<'a> {
 impl<'a> Scrollbars<'a> {
     pub fn both() -> Self {
         let mut this = Self::default();
-        this.static_css_props.insert("overflow", "auto".into());
+        this.static_css_props.insert("overflow", "auto");
         this
     }
 
     /// https://css-tricks.com/popping-hidden-overflow/
     pub fn x_and_clip_y() -> Self {
         let mut this = Self::default();
-        this.static_css_props.insert("overflow-x", "auto".into());
-        this.static_css_props.insert("overflow-y", "hidden".into());
+        this.static_css_props.insert("overflow-x", "auto");
+        this.static_css_props.insert("overflow-y", "hidden");
         this
     }
 
     /// https://css-tricks.com/popping-hidden-overflow/
     pub fn y_and_clip_x() -> Self {
         let mut this = Self::default();
-        this.static_css_props.insert("overflow-y", "auto".into());
-        this.static_css_props.insert("overflow-x", "hidden".into());
+        this.static_css_props.insert("overflow-y", "auto");
+        this.static_css_props.insert("overflow-x", "hidden");
         this
     }
 }
@@ -36,13 +36,21 @@ impl<'a> Style<'a> for Scrollbars<'a> {
         style_group: Option<StyleGroup<'a>>,
     ) -> (E, Option<StyleGroup<'a>>) {
         if let Some(mut style_group) = style_group {
-            for (name, value) in self.static_css_props {
-                style_group = style_group.style(name, value);
+            for (name, css_prop_value) in self.static_css_props {
+                style_group = if css_prop_value.important {
+                    style_group.style(name, css_prop_value.value)
+                } else {
+                    style_group.style_important(name, css_prop_value.value)
+                };
             }
             return (raw_el, Some(style_group));
         }
-        for (name, value) in self.static_css_props {
-            raw_el = raw_el.style(name, &value);
+        for (name, css_prop_value) in self.static_css_props {
+            raw_el = if css_prop_value.important {
+                raw_el.style_important(name, &css_prop_value.value)
+            } else {
+                raw_el.style(name, &css_prop_value.value)
+            };
         }
         (raw_el, None)
     }

--- a/crates/zoon/src/style/shadows.rs
+++ b/crates/zoon/src/style/shadows.rs
@@ -17,7 +17,7 @@ impl<'a> Shadows<'a> {
             .collect::<Cow<_>>()
             .join(", ");
         let mut this = Self::default();
-        this.static_css_props.insert("box-shadow", shadows.into());
+        this.static_css_props.insert("box-shadow", shadows);
         this
     }
 
@@ -45,16 +45,24 @@ impl<'a> Style<'a> for Shadows<'a> {
         style_group: Option<StyleGroup<'a>>,
     ) -> (E, Option<StyleGroup<'a>>) {
         if let Some(mut style_group) = style_group {
-            for (name, value) in self.static_css_props {
-                style_group = style_group.style(name, value);
+            for (name, css_prop_value) in self.static_css_props {
+                style_group = if css_prop_value.important {
+                    style_group.style(name, css_prop_value.value)
+                } else {
+                    style_group.style_important(name, css_prop_value.value)
+                };
             }
             for (name, value) in self.dynamic_css_props {
                 style_group = style_group.style_signal(name, value);
             }
             return (raw_el, Some(style_group));
         }
-        for (name, value) in self.static_css_props {
-            raw_el = raw_el.style(name, &value);
+        for (name, css_prop_value) in self.static_css_props {
+            raw_el = if css_prop_value.important {
+                raw_el.style_important(name, &css_prop_value.value)
+            } else {
+                raw_el.style(name, &css_prop_value.value)
+            };
         }
         for (name, value) in self.dynamic_css_props {
             raw_el = raw_el.style_signal(name, value);

--- a/crates/zoon/src/style/spacing.rs
+++ b/crates/zoon/src/style/spacing.rs
@@ -20,13 +20,21 @@ impl<'a> Style<'a> for Spacing<'a> {
         style_group: Option<StyleGroup<'a>>,
     ) -> (E, Option<StyleGroup<'a>>) {
         if let Some(mut style_group) = style_group {
-            for (name, value) in self.static_css_props {
-                style_group = style_group.style(name, value);
+            for (name, css_prop_value) in self.static_css_props {
+                style_group = if css_prop_value.important {
+                    style_group.style(name, css_prop_value.value)
+                } else {
+                    style_group.style_important(name, css_prop_value.value)
+                };
             }
             return (raw_el, Some(style_group));
         }
-        for (name, value) in self.static_css_props {
-            raw_el = raw_el.style(name, &value);
+        for (name, css_prop_value) in self.static_css_props {
+            raw_el = if css_prop_value.important {
+                raw_el.style_important(name, &css_prop_value.value)
+            } else {
+                raw_el.style(name, &css_prop_value.value)
+            };
         }
         (raw_el, None)
     }

--- a/crates/zoon/src/style/transform.rs
+++ b/crates/zoon/src/style/transform.rs
@@ -57,16 +57,24 @@ impl<'a> Style<'a> for Transform {
                 .rev()
                 .collect::<Vec<_>>()
                 .join(" ");
-            static_css_props.insert("transform", transform_value.into());
+            static_css_props.insert("transform", transform_value);
         }
         if let Some(mut style_group) = style_group {
-            for (name, value) in static_css_props {
-                style_group = style_group.style(name, value);
+            for (name, css_prop_value) in static_css_props {
+                style_group = if css_prop_value.important {
+                    style_group.style(name, css_prop_value.value)
+                } else {
+                    style_group.style_important(name, css_prop_value.value)
+                };
             }
             return (raw_el, Some(style_group));
         }
-        for (name, value) in static_css_props {
-            raw_el = raw_el.style(name, &value);
+        for (name, css_prop_value) in static_css_props {
+            raw_el = if css_prop_value.important {
+                raw_el.style_important(name, &css_prop_value.value)
+            } else {
+                raw_el.style(name, &css_prop_value.value)
+            };
         }
         (raw_el, None)
     }

--- a/crates/zoon/src/style/width.rs
+++ b/crates/zoon/src/style/width.rs
@@ -25,7 +25,7 @@ impl<'a> Width<'a> {
 
     pub fn fill() -> Self {
         let mut this = Self::default();
-        this.static_css_props.insert("width", "100%".into());
+        this.static_css_props.insert("width", "100%");
         this.static_css_classes.insert("fill_width".into());
         this.static_css_classes.remove("exact_width".into());
         this
@@ -49,16 +49,24 @@ impl<'a> Style<'a> for Width<'a> {
         style_group: Option<StyleGroup<'a>>,
     ) -> (E, Option<StyleGroup<'a>>) {
         if let Some(mut style_group) = style_group {
-            for (name, value) in self.static_css_props {
-                style_group = style_group.style(name, value);
+            for (name, css_prop_value) in self.static_css_props {
+                style_group = if css_prop_value.important {
+                    style_group.style(name, css_prop_value.value)
+                } else {
+                    style_group.style_important(name, css_prop_value.value)
+                };
             }
             for class in self.static_css_classes {
                 raw_el = raw_el.class(&class);
             }
             return (raw_el, Some(style_group));
         }
-        for (name, value) in self.static_css_props {
-            raw_el = raw_el.style(name, &value);
+        for (name, css_prop_value) in self.static_css_props {
+            raw_el = if css_prop_value.important {
+                raw_el.style_important(name, &css_prop_value.value)
+            } else {
+                raw_el.style(name, &css_prop_value.value)
+            };
         }
         for class in self.static_css_classes {
             raw_el = raw_el.class(&class);

--- a/crates/zoon/src/style/width.rs
+++ b/crates/zoon/src/style/width.rs
@@ -21,7 +21,8 @@ impl<'a> Width<'a> {
     ) -> Self {
         let mut this = Self::default();
         let width = width.map(|width| width.into().map(px));
-        this.dynamic_css_props.insert("width".into(), box_css_signal(width));
+        this.dynamic_css_props
+            .insert("width".into(), box_css_signal(width));
         this.static_css_classes.insert("exact_width".into());
         this.static_css_classes.remove("fill_width".into());
         this

--- a/examples/canvas/Cargo.lock
+++ b/examples/canvas/Cargo.lock
@@ -598,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "futures-signals"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7c31ebfcb97c87ac64db66a2d4d6ae71b487d5a8ef631c80c3d7e65a772a8c"
+checksum = "402d707a810e5fddfb1d5ff44174ffa96c6c1b136e7019cef5c9ef87c8977592"
 dependencies = [
  "discard",
  "futures-channel",

--- a/examples/chat/Cargo.lock
+++ b/examples/chat/Cargo.lock
@@ -648,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "futures-signals"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7c31ebfcb97c87ac64db66a2d4d6ae71b487d5a8ef631c80c3d7e65a772a8c"
+checksum = "402d707a810e5fddfb1d5ff44174ffa96c6c1b136e7019cef5c9ef87c8977592"
 dependencies = [
  "discard",
  "futures-channel",

--- a/examples/chat/frontend/src/app/view.rs
+++ b/examples/chat/frontend/src/app/view.rs
@@ -44,7 +44,7 @@ fn received_message(message: super::Message) -> impl Element {
         .item(
             El::new()
                 .s(Font::new()
-                    .weight(NamedWeight::Bold)
+                    .weight(FontWeight::Bold)
                     .color(GRAY_0)
                     .size(17))
                 .child(message.username),
@@ -74,7 +74,7 @@ fn message_text_to_contents(text: &str) -> impl Iterator<Item = RawElement> + '_
 fn emoji(name: &str) -> impl Element {
     Image::new()
         .s(Height::new(17))
-        .s(Transform::new().scale(230).move_up(2))
+        .s(Transform::new().scale(230).move_down(2))
         .s(Padding::new().x(5))
         .url([PUBLIC_URL, "emoji/", name, ".png"].concat())
         .description(name)

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "futures-signals"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7c31ebfcb97c87ac64db66a2d4d6ae71b487d5a8ef631c80c3d7e65a772a8c"
+checksum = "402d707a810e5fddfb1d5ff44174ffa96c6c1b136e7019cef5c9ef87c8977592"
 dependencies = [
  "discard",
  "futures-channel",

--- a/examples/counters/Cargo.lock
+++ b/examples/counters/Cargo.lock
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "futures-signals"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7c31ebfcb97c87ac64db66a2d4d6ae71b487d5a8ef631c80c3d7e65a772a8c"
+checksum = "402d707a810e5fddfb1d5ff44174ffa96c6c1b136e7019cef5c9ef87c8977592"
 dependencies = [
  "discard",
  "futures-channel",

--- a/examples/counters/frontend/src/app/view/element/counter.rs
+++ b/examples/counters/frontend/src/app/view/element/counter.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::rc::Rc;
+use std::{rc::Rc, iter};
 use zoon::*;
 
 // ------ ------
@@ -102,6 +102,16 @@ impl<ValueFlag, StepFlag> Element
                 on_change(step);
             }),
         )
+    }
+}
+
+impl<ValueFlag, ValueSignal, OnChangeFlag, StepFlag> IntoIterator for Counter<ValueFlag, ValueSignal, OnChangeFlag, StepFlag> {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
     }
 }
 

--- a/examples/js-framework-benchmark/keyed/Cargo.lock
+++ b/examples/js-framework-benchmark/keyed/Cargo.lock
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "futures-signals"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7c31ebfcb97c87ac64db66a2d4d6ae71b487d5a8ef631c80c3d7e65a772a8c"
+checksum = "402d707a810e5fddfb1d5ff44174ffa96c6c1b136e7019cef5c9ef87c8977592"
 dependencies = [
  "discard",
  "futures-channel",

--- a/examples/pages/Cargo.lock
+++ b/examples/pages/Cargo.lock
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "futures-signals"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7c31ebfcb97c87ac64db66a2d4d6ae71b487d5a8ef631c80c3d7e65a772a8c"
+checksum = "402d707a810e5fddfb1d5ff44174ffa96c6c1b136e7019cef5c9ef87c8977592"
 dependencies = [
  "discard",
  "futures-channel",

--- a/examples/pages/frontend/src/header.rs
+++ b/examples/pages/frontend/src/header.rs
@@ -34,7 +34,7 @@ fn back_button() -> impl Element {
 
 fn link(label: &str, route: Route) -> impl Element {
     Link::new()
-        .s(Font::new().underline().color(BLUE_4))
+        .s(Font::new().color(BLUE_4).line(FontLine::new().underline()))
         .label(label)
         .to(route)
 }

--- a/examples/pages/frontend/src/report_page.rs
+++ b/examples/pages/frontend/src/report_page.rs
@@ -93,7 +93,7 @@ fn greeting() -> impl Element {
 
 fn switch_frequency_link() -> impl Element {
     Link::new()
-        .s(Font::new().underline().color(BLUE_4))
+        .s(Font::new().color(BLUE_4).line(FontLine::new().underline()))
         .label_signal(
             frequency_for_link().map(|frequency| format!("Switch to {}", frequency.as_str())),
         )

--- a/examples/start_with_app/frontend/src/lib.rs
+++ b/examples/start_with_app/frontend/src/lib.rs
@@ -13,11 +13,12 @@ fn decrement() {
     counter().update(|counter| counter - 1)
 }
 
-fn root() -> impl Element {
-    Column::new()
-        .item(Button::new().label("-").on_press(decrement))
-        .item(Text::with_signal(counter().signal()))
-        .item(Button::new().label("+").on_press(increment))
+fn root() -> impl IntoIterator<Item = impl Element> {
+    element_vec![
+        Button::new().label("-").on_press(decrement),
+        Text::with_signal(counter().signal()),
+        Button::new().label("+").on_press(increment),
+    ]
 }
 
 #[wasm_bindgen(start)]

--- a/examples/svg/Cargo.lock
+++ b/examples/svg/Cargo.lock
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "futures-signals"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7c31ebfcb97c87ac64db66a2d4d6ae71b487d5a8ef631c80c3d7e65a772a8c"
+checksum = "402d707a810e5fddfb1d5ff44174ffa96c6c1b136e7019cef5c9ef87c8977592"
 dependencies = [
  "discard",
  "futures-channel",

--- a/examples/time_tracker/Cargo.lock
+++ b/examples/time_tracker/Cargo.lock
@@ -599,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "futures-signals"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7c31ebfcb97c87ac64db66a2d4d6ae71b487d5a8ef631c80c3d7e65a772a8c"
+checksum = "402d707a810e5fddfb1d5ff44174ffa96c6c1b136e7019cef5c9ef87c8977592"
 dependencies = [
  "discard",
  "futures-channel",

--- a/examples/time_tracker/frontend/src/app/view.rs
+++ b/examples/time_tracker/frontend/src/app/view.rs
@@ -40,7 +40,7 @@ fn header() -> impl Element {
 fn logo() -> impl Element {
     Link::new()
         .s(Height::fill())
-        .s(Font::new().weight(NamedWeight::Bold).size(32))
+        .s(Font::new().weight(FontWeight::Bold).size(32))
         .s(Padding::new().x(12))
         .to(Route::Root)
         .label(Row::new().s(Height::fill()).item("TT"))
@@ -159,7 +159,7 @@ fn login_button() -> impl Element {
             || theme::background_3_highlighted(),
             || theme::background_3(),
         )))
-        .s(Font::new().color_signal(theme::font_3()).weight(NamedWeight::Bold))
+        .s(Font::new().color_signal(theme::font_3()).weight(FontWeight::Bold))
         .s(Padding::new().x(15).y(10))
         .s(RoundedCorners::all(4))
         .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))
@@ -181,7 +181,7 @@ fn logout_button() -> impl Element {
         .on_press(super::log_out)
         .label(
             Row::new()
-                .item(El::new().s(Font::new().weight(NamedWeight::SemiBold)).child("Log out "))
+                .item(El::new().s(Font::new().weight(FontWeight::SemiBold)).child("Log out "))
                 .item(super::logged_user_name())
         )
 }

--- a/examples/time_tracker/frontend/src/clients_and_projects_page/view.rs
+++ b/examples/time_tracker/frontend/src/clients_and_projects_page/view.rs
@@ -15,7 +15,7 @@ fn title() -> impl Element {
         .s(
             Font::new()
                 .size(30)
-                .weight(NamedWeight::SemiBold)
+                .weight(FontWeight::SemiBold)
                 .color_signal(theme::font_0())
         )
         .child("Clients & Projects")
@@ -39,7 +39,7 @@ fn add_entity_button(title: &str, on_press: impl FnOnce() + Clone + 'static) -> 
                     || theme::background_3_highlighted(),
                     || theme::background_3(),
                 )))
-                .s(Font::new().color_signal(theme::font_3()).weight(NamedWeight::SemiBold))
+                .s(Font::new().color_signal(theme::font_3()).weight(FontWeight::SemiBold))
                 .s(Padding::all(5))
                 .s(RoundedCorners::all_max())
                 .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))
@@ -94,7 +94,7 @@ fn delete_entity_button(on_press: impl FnOnce() + Clone + 'static) -> impl Eleme
             || theme::background_3_highlighted(),
             || theme::background_3(),
         )))
-        .s(Font::new().color_signal(theme::font_3()).weight(NamedWeight::Bold))
+        .s(Font::new().color_signal(theme::font_3()).weight(FontWeight::Bold))
         .s(RoundedCorners::all_max())
         .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))
         .on_press(on_press)

--- a/examples/time_tracker/frontend/src/home_page/view.rs
+++ b/examples/time_tracker/frontend/src/home_page/view.rs
@@ -17,7 +17,7 @@ pub fn page() -> impl Element {
 
 fn title() -> impl Element {
     El::new()
-        .s(Font::new().size(50).weight(NamedWeight::SemiBold))
+        .s(Font::new().size(50).weight(FontWeight::SemiBold))
         .child("Time Tracker")
 }
 
@@ -32,7 +32,7 @@ fn moonzoon_link() -> impl Element {
 fn time_tracker_link() -> impl Element {
     let (hovered, hovered_signal) = Mutable::new_and_signal(false);
     Link::new()
-        .s(Font::new().weight(NamedWeight::Bold).color_signal(theme::font_3()).size(20).center())
+        .s(Font::new().weight(FontWeight::Bold).color_signal(theme::font_3()).size(20).center())
         .s(Padding::all(12).top(10))
         .s(RoundedCorners::all(6))
         .s(Background::new().color_signal(hovered_signal.map_bool_signal(

--- a/examples/time_tracker/frontend/src/login_page/view.rs
+++ b/examples/time_tracker/frontend/src/login_page/view.rs
@@ -24,7 +24,7 @@ pub fn page() -> impl Element {
 fn title() -> impl Element {
     El::new()
         .s(Align::new().center_x())
-        .s(Font::new().size(25).weight(NamedWeight::SemiBold))
+        .s(Font::new().size(25).weight(FontWeight::SemiBold))
         .child("Login")
 }
 
@@ -101,7 +101,7 @@ fn login_button() -> impl Element {
             || theme::background_3_highlighted(),
             || theme::background_3(),
         )))
-        .s(Font::new().color_signal(theme::font_3()).weight(NamedWeight::Bold))
+        .s(Font::new().color_signal(theme::font_3()).weight(FontWeight::Bold))
         .s(Padding::new().x(15).y(10))
         .s(RoundedCorners::all(4))
         .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))

--- a/examples/time_tracker/frontend/src/time_blocks_page/view.rs
+++ b/examples/time_tracker/frontend/src/time_blocks_page/view.rs
@@ -16,7 +16,7 @@ fn title() -> impl Element {
         .s(
             Font::new()
                 .size(30)
-                .weight(NamedWeight::SemiBold)
+                .weight(FontWeight::SemiBold)
                 .color_signal(theme::font_0())
         )
         .child("Time Blocks")
@@ -358,7 +358,7 @@ fn add_entity_button(title: &str, on_press: impl FnOnce() + Clone + 'static) -> 
                     || theme::background_3_highlighted(),
                     || theme::background_3(),
                 )))
-                .s(Font::new().color_signal(theme::font_3()).weight(NamedWeight::SemiBold))
+                .s(Font::new().color_signal(theme::font_3()).weight(FontWeight::SemiBold))
                 .s(Padding::all(5))
                 .s(RoundedCorners::all_max())
                 .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))
@@ -387,7 +387,7 @@ fn delete_entity_button(on_press: impl FnOnce() + Clone + 'static) -> impl Eleme
             || theme::background_3_highlighted(),
             || theme::background_3(),
         )))
-        .s(Font::new().color_signal(theme::font_3()).weight(NamedWeight::Bold))
+        .s(Font::new().color_signal(theme::font_3()).weight(FontWeight::Bold))
         .s(RoundedCorners::all_max())
         .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))
         .on_press(on_press)
@@ -404,7 +404,7 @@ fn link_button(invoice: Arc<super::Invoice>) -> impl Element {
             || theme::background_3_highlighted(),
             || theme::background_3(),
         )))
-        .s(Font::new().color_signal(theme::font_3()).weight(NamedWeight::Bold))
+        .s(Font::new().color_signal(theme::font_3()).weight(FontWeight::Bold))
         .s(RoundedCorners::all_max())
         .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))
         .to_signal(invoice.url.signal_cloned())

--- a/examples/time_tracker/frontend/src/time_tracker_page/view.rs
+++ b/examples/time_tracker/frontend/src/time_tracker_page/view.rs
@@ -15,7 +15,7 @@ fn title() -> impl Element {
         .s(
             Font::new()
                 .size(30)
-                .weight(NamedWeight::SemiBold)
+                .weight(FontWeight::SemiBold)
                 .color_signal(theme::font_0())
         )
         .child("Time Tracker")
@@ -268,7 +268,7 @@ fn delete_entity_button(on_press: impl FnOnce() + Clone + 'static, is_active: Re
                 || theme::font_1(), 
                 || theme::font_3(),
             ))
-            .weight(NamedWeight::Bold)
+            .weight(FontWeight::Bold)
         )
         .s(RoundedCorners::all_max())
         .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))
@@ -705,7 +705,7 @@ fn date_time_part_input(
                     || theme::font_1(),
                 ))
                 .center()
-                .weight(if bold { NamedWeight::Bold } else { NamedWeight::Regular } )
+                .weight(if bold { FontWeight::Bold } else { FontWeight::Regular } )
         )
         .s(Background::new().color_signal(valid_signal.map_bool_signal(
             || theme::transparent(), 

--- a/examples/timer/Cargo.lock
+++ b/examples/timer/Cargo.lock
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "futures-signals"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7c31ebfcb97c87ac64db66a2d4d6ae71b487d5a8ef631c80c3d7e65a772a8c"
+checksum = "402d707a810e5fddfb1d5ff44174ffa96c6c1b136e7019cef5c9ef87c8977592"
 dependencies = [
  "discard",
  "futures-channel",

--- a/examples/todomvc/Cargo.lock
+++ b/examples/todomvc/Cargo.lock
@@ -598,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "futures-signals"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7c31ebfcb97c87ac64db66a2d4d6ae71b487d5a8ef631c80c3d7e65a772a8c"
+checksum = "402d707a810e5fddfb1d5ff44174ffa96c6c1b136e7019cef5c9ef87c8977592"
 dependencies = [
  "discard",
  "futures-channel",

--- a/examples/todomvc/frontend/src/app/view.rs
+++ b/examples/todomvc/frontend/src/app/view.rs
@@ -11,7 +11,7 @@ pub fn root() -> impl Element {
         .s(Font::new()
             .size(14)
             .color(hsluv!(0, 0, 5.1))
-            .weight(NamedWeight::Light)
+            .weight(FontWeight::Light)
             .family(vec![
                 FontFamily::new("Helvetica Neue"),
                 FontFamily::new("Helvetica"),
@@ -44,7 +44,7 @@ fn header() -> impl Element {
         .s(Font::new()
             .size(100)
             .color(hsluv!(10.5, 62.8, 44.5, 15))
-            .weight(NamedWeight::Hairline))
+            .weight(FontWeight::Hairline))
         .child(El::with_tag(Tag::H1).child("todos"))
 }
 
@@ -153,14 +153,16 @@ fn todo_title(todo: Arc<Todo>) -> impl Element {
     let (hovered, hovered_signal) = Mutable::new_and_signal(false);
     Label::new()
         .s(Width::fill())
-        .s(Font::new()
-            .color_signal(
-                todo.completed
-                    .signal()
-                    .map_bool(|| hsluv!(0, 0, 86.7), || hsluv!(0, 0, 32.7)),
-            )
-            .strike_signal(todo.completed.signal())
-            .size(24))
+        .s(
+            Font::new()
+                .color_signal(
+                    todo.completed
+                        .signal()
+                        .map_bool(|| hsluv!(0, 0, 86.7), || hsluv!(0, 0, 32.7)),
+                )
+                .size(24)
+                .line(FontLine::new().strike_signal(todo.completed.signal()))
+        )
         .s(Padding::all(15).right(60))
         .s(Clip::x())
         .for_input(todo.id.to_string())
@@ -288,7 +290,7 @@ fn clear_completed_button() -> impl Element {
     let (hovered, hovered_signal) = Mutable::new_and_signal(false);
     Button::new()
         .s(Align::new().right())
-        .s(Font::new().underline_signal(hovered_signal))
+        .s(Font::new().line(FontLine::new().underline_signal(hovered_signal)))
         .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))
         .on_press(super::remove_completed_todos)
         .label("Clear completed")
@@ -310,7 +312,7 @@ fn footer() -> impl Element {
 fn author_link() -> impl Element {
     let (hovered, hovered_signal) = Mutable::new_and_signal(false);
     Link::new()
-        .s(Font::new().underline_signal(hovered_signal))
+        .s(Font::new().line(FontLine::new().underline_signal(hovered_signal)))
         .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))
         .label("Martin Kavík")
         .to("https://github.com/MartinKavik")
@@ -320,7 +322,7 @@ fn author_link() -> impl Element {
 fn todomvc_link() -> impl Element {
     let (hovered, hovered_signal) = Mutable::new_and_signal(false);
     Link::new()
-        .s(Font::new().underline_signal(hovered_signal))
+        .s(Font::new().line(FontLine::new().underline_signal(hovered_signal)))
         .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))
         .label("TodoMVC")
         .to("http://todomvc.com")

--- a/examples/viewport/Cargo.lock
+++ b/examples/viewport/Cargo.lock
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "futures-signals"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7c31ebfcb97c87ac64db66a2d4d6ae71b487d5a8ef631c80c3d7e65a772a8c"
+checksum = "402d707a810e5fddfb1d5ff44174ffa96c6c1b136e7019cef5c9ef87c8977592"
 dependencies = [
  "discard",
  "futures-channel",


### PR DESCRIPTION
- `Element` requires `IntoIterator`. Implemented `IntoIterator` for all elements. 
- `Paragraph` styles: `vertical-align` removed, `inline-flex` replaced with `inline` and flagged `important`.
- Added the method `style_important` to multiple items. 
- `futures_signals` version updated.
- `start_app`'s `view_root` function returns `impl IntoIterator<Item = impl Element>`. 
- Added `Font::line` + `FontLine`. (Replaces `Font::underline` and similar methods.)
- Added `Font::size_signal`.
- `NamedWeight` replaced with `FontWeight`. `FontWeight` has an extra variant `Number(u32)` and the method `number()`.
- Added `Height::with_signal` and `Width::with_signal`.
- Added `*_signal` alternatives for all `Padding` methods.
- Updated all examples.
- `StaticCSSProps` rewritten.