### PR TITLE
Cors, Transitions and Timer and Transform API updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,6 +2835,7 @@ dependencies = [
  "console_error_panic_hook",
  "dominator",
  "enclose",
+ "futures-channel",
  "futures-signals",
  "futures-util",
  "gensym",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.6.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa59d36d7ad063401d94ada05264a303791796ad5222d0954cc21f2e1052e99b"
+dependencies = [
+ "actix-service",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec 1.6.1",
+]
+
+[[package]]
 name = "actix-files"
 version = "0.6.0-beta.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1272,7 @@ dependencies = [
 name = "moon"
 version = "0.1.0"
 dependencies = [
+ "actix-cors",
  "actix-files",
  "actix-http",
  "actix-rt",

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -14,6 +14,7 @@ mime_guess = { version = "2.0.3", default-features = false }
 actix-web = { version = "=4.0.0-beta.10", features = ["rustls"], default-features = false }
 actix-files = { version = "=0.6.0-beta.8", default-features = false }
 actix-http = { version = "=3.0.0-beta.11", default-features = false }
+actix-cors = { version = "=0.6.0-beta.3", default-features = false }
 rustls = { version = "=0.20.0", default-features = false }
 rustls-pemfile = { version = "=0.2.1", default-features = false }
 actix-rt = { version = "=2.3.0", default-features = false }

--- a/crates/moon/src/config.rs
+++ b/crates/moon/src/config.rs
@@ -2,6 +2,8 @@ use crate::from_env_vars::FromEnvVars;
 use log::LevelFilter;
 pub use once_cell::sync::Lazy;
 use serde::Deserialize;
+use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 pub static CONFIG: Lazy<Config> = Lazy::new(Config::from_env_vars);
 
@@ -21,6 +23,9 @@ pub struct Config {
 
     #[serde(default = "Redirect::from_env_vars")]
     pub redirect: Redirect,
+
+    #[serde(default = "Cors::from_env_vars")]
+    pub cors: Cors,
 }
 
 impl FromEnvVars for Config {
@@ -36,6 +41,7 @@ impl Default for Config {
             cache_busting: true,
             backend_log_level: LevelFilter::Warn,
             redirect: Redirect::default(),
+            cors: Cors::default(),
         }
     }
 }
@@ -59,6 +65,26 @@ impl Default for Redirect {
         Self {
             port: 8081,
             enabled: false,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct Cors {
+    // CORS_ORIGINS="http://localhost:8080,http://127.0.0.1:8080,*"
+    pub origins: BTreeSet<Cow<'static, str>>,
+}
+
+impl FromEnvVars for Cors {
+    const ENTITY_NAME: &'static str = "Cors";
+    const ENV_PREFIX: &'static str = "CORS_";
+}
+
+impl Default for Cors {
+    fn default() -> Self {
+        Self {
+            origins: BTreeSet::from_iter(["*".into()]),
         }
     }
 }

--- a/crates/moon/src/lib.rs
+++ b/crates/moon/src/lib.rs
@@ -428,11 +428,19 @@ fn named_file_and_encoding(
 
     if accept_encodings.contains(ContentEncoding::Br.as_str()) {
         file.push_str(".br");
-        return Ok((NamedFile::open(file)?, Some(ContentEncoding::Br)));
+        let named_file = NamedFile::open(&file);
+        if named_file.is_err() {
+            eprintln!("Cannot load '{}'. Consider to set `ENV COMPRESSED_PKG false` or build with `mzoon build -r`.", file);
+        }
+        return Ok((named_file?, Some(ContentEncoding::Br)));
     }
     if accept_encodings.contains(ContentEncoding::Gzip.as_str()) {
         file.push_str(".gz");
-        return Ok((NamedFile::open(file)?, Some(ContentEncoding::Gzip)));
+        let named_file = NamedFile::open(&file);
+        if named_file.is_err() {
+            eprintln!("Cannot load '{}'. Consider to set `ENV COMPRESSED_PKG false` or build with `mzoon build -r`.", file);
+        }
+        return Ok((named_file?, Some(ContentEncoding::Gzip)));
     }
     Ok((NamedFile::open(file)?, None))
 }

--- a/crates/mzoon/src/config.rs
+++ b/crates/mzoon/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub cache_busting: bool,
     pub backend_log_level: LevelFilter,
     pub redirect: Redirect,
+    pub cors: Cors,
     pub watch: Watch,
 }
 
@@ -28,6 +29,11 @@ impl Config {
 pub struct Redirect {
     pub port: u16,
     pub enabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Cors {
+    pub origins: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/mzoon/src/set_env_vars.rs
+++ b/crates/mzoon/src/set_env_vars.rs
@@ -17,5 +17,9 @@ pub fn set_env_vars(config: &Config, release: bool) {
     // enabled = true
     env::set_var("REDIRECT_ENABLED", config.redirect.enabled.to_string());
 
+    // [cors]
+    // origins = ["*", "https://example.com"]
+    env::set_var("CORS_ORIGINS", config.cors.origins.join(","));
+
     env::set_var("COMPRESSED_PKG", release.to_string());
 }

--- a/crates/zoon/Cargo.toml
+++ b/crates/zoon/Cargo.toml
@@ -10,6 +10,7 @@ wasm-bindgen-futures = { version = "0.4.26", default-features = false }
 js-sys = { version = "0.3.53", default-features = false }
 futures-signals = { version = "0.3.23", default-features = false }
 futures-util = { version = "0.3.15", default-features = false }
+futures-channel = { version = "0.3.17", default-features = false }
 dominator = { version = "0.5.22", default-features = false }
 paste = { version = "1.0.5", default-features = false }
 send_wrapper = { version = "0.5.0", default-features = false }

--- a/crates/zoon/src/lib.rs
+++ b/crates/zoon/src/lib.rs
@@ -172,10 +172,10 @@ macro_rules! run_once {
         $crate::gensym! { $crate::run_once!($f) }
     };
     ($random_ident:ident, $f:expr) => {
-        $crate::paste! {
+        $crate::paste! {{
             static [<RUN_ONCE $random_ident:snake:upper>]: std::sync::Once = std::sync::Once::new();
             [<RUN_ONCE $random_ident:snake:upper>].call_once($f);
-        }
+        }}
     };
 }
 

--- a/crates/zoon/src/lib.rs
+++ b/crates/zoon/src/lib.rs
@@ -36,6 +36,7 @@ pub use dom_builder_ext::DomBuilderExt;
 pub use dominator::{self, events, traits::StaticEvent, Dom, DomBuilder};
 pub use either::{Either, IntoEither};
 pub use element::*;
+pub use futures_channel::{self, oneshot};
 pub use futures_signals::{
     self, map_mut, map_ref,
     signal::{

--- a/crates/zoon/src/style.rs
+++ b/crates/zoon/src/style.rs
@@ -47,6 +47,9 @@ pub use shadows::{Shadow, Shadows};
 mod spacing;
 pub use spacing::Spacing;
 
+mod transitions;
+pub use transitions::{Transitions, Transition};
+
 mod transform;
 pub use transform::Transform;
 

--- a/crates/zoon/src/style.rs
+++ b/crates/zoon/src/style.rs
@@ -48,7 +48,7 @@ mod spacing;
 pub use spacing::Spacing;
 
 mod transitions;
-pub use transitions::{Transitions, Transition};
+pub use transitions::{Transition, Transitions};
 
 mod transform;
 pub use transform::Transform;

--- a/crates/zoon/src/style/transform.rs
+++ b/crates/zoon/src/style/transform.rs
@@ -12,10 +12,13 @@ impl Transform {
         transform: impl Signal<Item = impl Into<Option<Self>>> + Unpin + 'static,
     ) -> Self {
         let mut this = Self::default();
-        let transform = transform.map(|transform| { 
-            transform.into().map(|mut transform| transform.transformations_into_value())
+        let transform = transform.map(|transform| {
+            transform
+                .into()
+                .map(|mut transform| transform.transformations_into_value())
         });
-        this.dynamic_css_props.insert("transform".into(), box_css_signal(transform));
+        this.dynamic_css_props
+            .insert("transform".into(), box_css_signal(transform));
         this
     }
 
@@ -58,7 +61,7 @@ impl Transform {
     fn transformations_into_value(&mut self) -> Cow<'static, str> {
         let transformations = mem::take(&mut self.transformations);
         if transformations.is_empty() {
-            return "none".into()
+            return "none".into();
         }
         transformations
             .into_iter()

--- a/crates/zoon/src/style/transitions.rs
+++ b/crates/zoon/src/style/transitions.rs
@@ -1,0 +1,136 @@
+use crate::*;
+use std::borrow::Cow;
+
+// ------ Transitions ------
+
+#[derive(Default)]
+pub struct Transitions<'a> {
+    static_css_props: StaticCSSProps<'a>,
+    dynamic_css_props: DynamicCSSProps,
+}
+
+impl<'a> Transitions<'a> {
+    pub fn new(transitions: impl IntoIterator<Item = Transition>) -> Self {
+        let transitions = transitions
+            .into_iter()
+            .map(|shadow| shadow.into_cow_str())
+            .collect::<Cow<_>>()
+            .join(", ");
+        let mut this = Self::default();
+        this.static_css_props.insert("transition", transitions);
+        this
+    }
+
+    pub fn with_signal(
+        transitions: impl Signal<Item = impl IntoIterator<Item = Transition>> + Unpin + 'static,
+    ) -> Self {
+        let transitions = transitions.map(|transitions| {
+            transitions
+                .into_iter()
+                .map(|shadow| shadow.into_cow_str())
+                .collect::<Cow<_>>()
+                .join(", ")
+        });
+        let mut this = Self::default();
+        this.dynamic_css_props
+            .insert("transition".into(), box_css_signal(transitions));
+        this
+    }
+}
+
+impl<'a> Style<'a> for Transitions<'a> {
+    fn apply_to_raw_el<E: RawEl>(
+        self,
+        mut raw_el: E,
+        style_group: Option<StyleGroup<'a>>,
+    ) -> (E, Option<StyleGroup<'a>>) {
+        if let Some(mut style_group) = style_group {
+            for (name, css_prop_value) in self.static_css_props {
+                style_group = if css_prop_value.important {
+                    style_group.style(name, css_prop_value.value)
+                } else {
+                    style_group.style_important(name, css_prop_value.value)
+                };
+            }
+            for (name, value) in self.dynamic_css_props {
+                style_group = style_group.style_signal(name, value);
+            }
+            return (raw_el, Some(style_group));
+        }
+        for (name, css_prop_value) in self.static_css_props {
+            raw_el = if css_prop_value.important {
+                raw_el.style_important(name, &css_prop_value.value)
+            } else {
+                raw_el.style(name, &css_prop_value.value)
+            };
+        }
+        for (name, value) in self.dynamic_css_props {
+            raw_el = raw_el.style_signal(name, value);
+        }
+        (raw_el, None)
+    }
+}
+
+// ------ Transition ------
+
+pub struct Transition {
+    property: Cow<'static, str>,
+    duration: u32,
+}
+
+impl Default for Transition {
+    fn default() -> Self {
+        Self {
+            property: "all".into(),
+            duration: 1000,
+        }
+    }
+}
+
+impl Transition {
+    pub fn property(property: impl IntoCowStr<'static>) -> Self {
+        Self {
+            property: property.into_cow_str(),
+            ..Self::default()
+        }
+    }
+
+    pub fn all() -> Self {
+        Self::default()
+    }
+
+    pub fn width() -> Self {
+        Self::property("width")
+    }
+
+    pub fn height() -> Self {
+        Self::property("height")
+    }
+
+    pub fn transform() -> Self {
+        Self::property("transform")
+    }
+
+    pub fn color() -> Self {
+        Self::property("color")
+    }
+
+    pub fn background_color() -> Self {
+        Self::property("background-color")
+    }
+
+    pub fn duration(mut self, ms: u32) -> Self {
+        self.duration = ms;
+        self
+    }
+}
+
+impl<'a> IntoCowStr<'a> for Transition {
+    fn into_cow_str(self) -> Cow<'a, str> {
+        crate::format!("{} {}ms", self.property, self.duration).into()
+    }
+
+    fn take_into_cow_str(&mut self) -> Cow<'a, str> {
+        unimplemented!()
+    }
+}

--- a/crates/zoon/src/timer.rs
+++ b/crates/zoon/src/timer.rs
@@ -4,14 +4,18 @@ use crate::*;
 
 pub struct Timer {
     handle: Option<JsHandle>,
-    on_tick: SendWrapper<Closure<dyn Fn()>>,
+    #[allow(dead_code)]
+    on_tick: SendWrapper<Closure<dyn FnMut()>>,
 }
 
 impl Timer {
     pub fn new(ms: u32, on_tick: impl FnOnce() + Clone + 'static) -> Self {
-        let mut this = Self::without_handle(on_tick);
-        this.handle = Some(JsHandle::Interval(set_interval(&this.on_tick, ms)));
-        this
+        let on_tick = move || (on_tick.clone())();
+        let on_tick = Closure::wrap(Box::new(on_tick) as Box<dyn FnMut()>);
+        Self {
+            handle: Some(JsHandle::Interval(set_interval(&on_tick, ms))),
+            on_tick: SendWrapper::new(on_tick),
+        }
     }
 
     pub fn new_immediate(ms: u32, on_tick: impl FnOnce() + Clone + 'static) -> Self {
@@ -19,19 +23,24 @@ impl Timer {
         Self::new(ms, on_tick)
     }
 
-    pub fn once(ms: u32, on_tick: impl FnOnce() + Clone + 'static) -> Self {
-        let mut this = Self::without_handle(on_tick);
-        this.handle = Some(JsHandle::Timeout(set_timeout(&this.on_tick, ms)));
-        this
-    }
-
-    fn without_handle(on_tick: impl FnOnce() + Clone + 'static) -> Self {
-        let on_tick = move || (on_tick.clone())();
-        let on_tick = Closure::wrap(Box::new(on_tick) as Box<dyn Fn()>);
+    pub fn once(ms: u32, on_tick: impl FnOnce() + 'static) -> Self {
+        let on_tick = Closure::once(on_tick);
         Self {
-            handle: None,
+            handle: Some(JsHandle::Timeout(set_timeout(&on_tick, ms))),
             on_tick: SendWrapper::new(on_tick),
         }
+    }
+
+    pub async fn sleep(ms: u32) {
+        let (sender, receiver) = oneshot::channel();
+        let _timer = Self::once(ms, move || {
+            sender
+                .send(())
+                .expect_throw("`sender` failed in `Timer::sleep`")
+        });
+        receiver
+            .await
+            .expect_throw("`receiver` failed in `Timer::sleep`")
     }
 }
 
@@ -56,13 +65,13 @@ enum JsHandle {
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_name = setInterval)]
-    fn set_interval(callback: &Closure<dyn Fn()>, ms: u32) -> f64;
+    fn set_interval(callback: &Closure<dyn FnMut()>, ms: u32) -> f64;
 
     #[wasm_bindgen(js_name = clearInterval)]
     fn clear_interval(token: f64);
 
     #[wasm_bindgen(js_name = setTimeout)]
-    fn set_timeout(callback: &Closure<dyn Fn()>, ms: u32) -> f64;
+    fn set_timeout(callback: &Closure<dyn FnMut()>, ms: u32) -> f64;
 
     #[wasm_bindgen(js_name = clearTimeout)]
     fn clear_timeout(token: f64);

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -409,6 +409,23 @@ fn element_with_raw_styles() -> impl Element {
 - `StyleGroup` selector is prefixed by a unique element _class id_ - e.g. `._13:hover .icon`.
 - `StyleGroup`s are stored among the global styles and dropped when the associated element is removed from the DOM.
 
+### Animated styles
+
+```rust
+fn sidebar() -> impl Element {
+    Column::new()
+        .s(Width::with_signal(sidebar_expanded().signal().map_bool(|| 180, || 48)))
+        .s(Transitions::new([Transition::width().duration(500)]))
+        .s(Clip::both())
+        .item(toggle_button())
+        .item(menu())
+}
+```
+
+- Use `Transitions` with an iterator of `Transition` to create basic animations.
+- There are some typed properties like `Transition::width()` and `::height()`, but you can use also `::all()` and custom property names with `::property("font-size")`.
+- Let us know when you want to add another typed property. [The list of supported properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animated_properties). 
+
 ---
 ## Color
 
@@ -805,7 +822,7 @@ fn save_todos() {
         </details>
         
 1. _"How are we taking care of animations?"_ (by None on [chat](https://discord.gg/eGduTxK2Es))
-   - The API for animations haven't been designed yet. We'll probably focus on it once we have a proof-of-concept of the basic MoonZoon features.
+   - The API for advanced animations haven't been designed yet. See the sub-section `Animated styles` for basic examples.
    - Inspiration:
       - [react-spring](https://www.react-spring.io/)
       - [Framer Motion](https://www.framer.com/motion/)

--- a/examples/canvas/MoonZoon.toml
+++ b/examples/canvas/MoonZoon.toml
@@ -8,6 +8,9 @@ backend_log_level = "warn" # "error" / "warn" / "info" / "debug" / "trace"
 port = 8081
 enabled = false
 
+[cors]
+origins = ["*"]
+
 [watch]
 frontend = [
     "public",

--- a/examples/chat/MoonZoon.toml
+++ b/examples/chat/MoonZoon.toml
@@ -8,6 +8,9 @@ backend_log_level = "warn" # "error" / "warn" / "info" / "debug" / "trace"
 port = 8081
 enabled = false
 
+[cors]
+origins = ["*"]
+
 [watch]
 frontend = [
     "public",

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -2067,6 +2067,7 @@ dependencies = [
  "console_error_panic_hook",
  "dominator",
  "enclose",
+ "futures-channel",
  "futures-signals",
  "futures-util",
  "gensym",

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -19,6 +19,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.6.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa59d36d7ad063401d94ada05264a303791796ad5222d0954cc21f2e1052e99b"
+dependencies = [
+ "actix-service",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec 1.6.1",
+]
+
+[[package]]
 name = "actix-files"
 version = "0.6.0-beta.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +940,7 @@ dependencies = [
 name = "moon"
 version = "0.1.0"
 dependencies = [
+ "actix-cors",
  "actix-files",
  "actix-http",
  "actix-rt",

--- a/examples/counter/MoonZoon.toml
+++ b/examples/counter/MoonZoon.toml
@@ -8,6 +8,9 @@ backend_log_level = "warn" # "error" / "warn" / "info" / "debug" / "trace"
 port = 8081
 enabled = false
 
+[cors]
+origins = ["*"]
+
 [watch]
 frontend = [
     "public",

--- a/examples/counters/MoonZoon.toml
+++ b/examples/counters/MoonZoon.toml
@@ -8,6 +8,9 @@ backend_log_level = "warn" # "error" / "warn" / "info" / "debug" / "trace"
 port = 8081
 enabled = false
 
+[cors]
+origins = ["*"]
+
 [watch]
 frontend = [
     "public",

--- a/examples/js-framework-benchmark/keyed/MoonZoon.toml
+++ b/examples/js-framework-benchmark/keyed/MoonZoon.toml
@@ -8,6 +8,9 @@ backend_log_level = "warn" # "error" / "warn" / "info" / "debug" / "trace"
 port = 8081
 enabled = false
 
+[cors]
+origins = ["*"]
+
 [watch]
 frontend = [
     "public",

--- a/examples/pages/MoonZoon.toml
+++ b/examples/pages/MoonZoon.toml
@@ -8,6 +8,9 @@ backend_log_level = "warn" # "error" / "warn" / "info" / "debug" / "trace"
 port = 8081
 enabled = false
 
+[cors]
+origins = ["*"]
+
 [watch]
 frontend = [
     "public",

--- a/examples/start_with_app/Cargo.lock
+++ b/examples/start_with_app/Cargo.lock
@@ -19,6 +19,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.6.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa59d36d7ad063401d94ada05264a303791796ad5222d0954cc21f2e1052e99b"
+dependencies = [
+ "actix-service",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec 1.7.0",
+]
+
+[[package]]
 name = "actix-files"
 version = "0.6.0-beta.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +939,7 @@ dependencies = [
 name = "moon"
 version = "0.1.0"
 dependencies = [
+ "actix-cors",
  "actix-files",
  "actix-http",
  "actix-rt",

--- a/examples/start_with_app/MoonZoon.toml
+++ b/examples/start_with_app/MoonZoon.toml
@@ -8,6 +8,9 @@ backend_log_level = "warn" # "error" / "warn" / "info" / "debug" / "trace"
 port = 8081
 enabled = false
 
+[cors]
+origins = ["*"]
+
 [watch]
 frontend = [
     "public",

--- a/examples/start_with_app/backend/src/main.rs
+++ b/examples/start_with_app/backend/src/main.rs
@@ -8,6 +8,7 @@ use moon::{
         get,
         Responder,
     },
+    actix_cors::Cors,
     config::CONFIG,
 };
 
@@ -49,6 +50,18 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .wrap(Condition::new(CONFIG.redirect.enabled, Compat::new(redirect)))
             .wrap(Logger::new("%r %s %D ms %a"))
+            .wrap(Cors::default()
+                .allowed_origin_fn(move |origin, _| {
+                    if CONFIG.cors.origins.contains("*") {
+                        return true;
+                    }
+                    let origin = match origin.to_str() {
+                        Ok(origin) => origin,
+                        Err(_) => return false,
+                    };
+                    CONFIG.cors.origins.contains(origin)
+                })
+            )
             .wrap(
                 ErrorHandlers::new()
                     .handler(

--- a/examples/svg/MoonZoon.toml
+++ b/examples/svg/MoonZoon.toml
@@ -8,6 +8,9 @@ backend_log_level = "warn" # "error" / "warn" / "info" / "debug" / "trace"
 port = 8081
 enabled = false
 
+[cors]
+origins = ["*"]
+
 [watch]
 frontend = [
     "frontend/Cargo.toml",

--- a/examples/time_tracker/MoonZoon.toml
+++ b/examples/time_tracker/MoonZoon.toml
@@ -8,6 +8,9 @@ backend_log_level = "warn" # "error" / "warn" / "info" / "debug" / "trace"
 port = 8081
 enabled = false
 
+[cors]
+origins = ["*"]
+
 [watch]
 frontend = [
     "public",

--- a/examples/timer/Cargo.lock
+++ b/examples/timer/Cargo.lock
@@ -19,6 +19,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.6.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa59d36d7ad063401d94ada05264a303791796ad5222d0954cc21f2e1052e99b"
+dependencies = [
+ "actix-service",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec 1.6.1",
+]
+
+[[package]]
 name = "actix-files"
 version = "0.6.0-beta.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -571,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-io"
@@ -610,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "futures-task"
@@ -924,6 +939,7 @@ dependencies = [
 name = "moon"
 version = "0.1.0"
 dependencies = [
+ "actix-cors",
  "actix-files",
  "actix-http",
  "actix-rt",
@@ -2011,6 +2027,7 @@ dependencies = [
  "console_error_panic_hook",
  "dominator",
  "enclose",
+ "futures-channel",
  "futures-signals",
  "futures-util",
  "gensym",

--- a/examples/timer/MoonZoon.toml
+++ b/examples/timer/MoonZoon.toml
@@ -8,6 +8,9 @@ backend_log_level = "warn" # "error" / "warn" / "info" / "debug" / "trace"
 port = 8081
 enabled = false
 
+[cors]
+origins = ["*"]
+
 [watch]
 frontend = [
     "public",

--- a/examples/todomvc/MoonZoon.toml
+++ b/examples/todomvc/MoonZoon.toml
@@ -8,6 +8,9 @@ backend_log_level = "warn" # "error" / "warn" / "info" / "debug" / "trace"
 port = 8081
 enabled = false
 
+[cors]
+origins = ["*"]
+
 [watch]
 frontend = [
     "public",

--- a/examples/viewport/MoonZoon.toml
+++ b/examples/viewport/MoonZoon.toml
@@ -8,6 +8,9 @@ backend_log_level = "warn" # "error" / "warn" / "info" / "debug" / "trace"
 port = 8081
 enabled = false
 
+[cors]
+origins = ["*"]
+
 [watch]
 frontend = [
     "public",


### PR DESCRIPTION
- Reexported `actix_cors` in Moon.
- Reexported `futures-channel` and its `oneshot` in Zoon.
- `run_once` is usable on more places.
- Added the _style_ `Transitions` with the related entity `Transition`.
- Added the method `Transform::with_signal`.
- Relaxed `Timer::once` (`on_tick` no longer needs `Clone`).
- Added the `async` method `Timer::sleep`. 
- Updated the `timer` example to exercise `Timer::sleep`.
- Updated `Timer` documentation in `frontend.md`.
- CORS origins have to be configured in `MoonZoon.toml`. (Only `*` or full urls without paths are allowed; See the snippet bellow).
- Added CORS settings to all examples:
   ```toml
   [cors]
   origins = ["*"]
   ```