### PR TITLE
fix: use full-length commit SHA1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 [[package]]
 name = "lexical"
 version = "6.0.0"
-source = "git+https://github.com/Alexhuszagh/rust-lexical?rev=7010efd#7010efd5e144faff0c9afbc1b22b47d9d9567966"
+source = "git+https://github.com/Alexhuszagh/rust-lexical?rev=7010efd5e144faff0c9afbc1b22b47d9d9567966#7010efd5e144faff0c9afbc1b22b47d9d9567966"
 dependencies = [
  "cfg-if 1.0.0",
  "lexical-core",
@@ -1138,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "lexical-core"
 version = "0.8.0"
-source = "git+https://github.com/Alexhuszagh/rust-lexical?rev=7010efd#7010efd5e144faff0c9afbc1b22b47d9d9567966"
+source = "git+https://github.com/Alexhuszagh/rust-lexical?rev=7010efd5e144faff0c9afbc1b22b47d9d9567966#7010efd5e144faff0c9afbc1b22b47d9d9567966"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",

--- a/crates/zoon/Cargo.toml
+++ b/crates/zoon/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = { version = "1.0.26", default-features = false, optional = true }
 chrono = { version = "0.4", default-features = false, optional = true }
 
 ufmt = { version = "0.1.0", features = ["std"], default-features = false, optional = true }
-lexical = { git = "https://github.com/Alexhuszagh/rust-lexical", rev = "7010efd", features = ["std"], default-features = false, optional = true }
+lexical = { git = "https://github.com/Alexhuszagh/rust-lexical", rev = "7010efd5e144faff0c9afbc1b22b47d9d9567966", features = ["std"], default-features = false, optional = true }
 
 [dependencies.web-sys]
 version = "0.3.53"


### PR DESCRIPTION
Prior to this change, the tools I use, namely [Nix] and [naersk], imports and parses the Cargo.lock file in order to reproducibly
determine the set of crates that need to be downloaded.  During this process it appears that naersk does additional validation of crates' rev and results in the following error:

    error: hash '7010efd' has wrong length for hash type 'sha1'

This change simply specifies the full hash for the crate that causes the error, which is sufficient to resolve the error and also has no impact on other build tools.

Note that it may better to just update the dependencies... :shrug: 

[Nix]: https://nixos.org/
[naersk]: https://github.com/nix-community/naersk