### PR TITLE
Fix Actix deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "actix-router"
-version = "0.5.0-beta.3"
+version = "0.5.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd9f117b910fbcce6e9f45092ffd4ff017785a346d09e2d4fd049f4e20384f4"
+checksum = "36b95ce0d76d1aa2f98b681702807475ade0f99bd4552546a6843a966d42ea3d"
 dependencies = [
  "bytestring",
  "firestorm",
@@ -1277,6 +1277,7 @@ dependencies = [
  "actix-cors",
  "actix-files",
  "actix-http",
+ "actix-router",
  "actix-rt",
  "actix-tls",
  "actix-web",

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -11,14 +11,19 @@ futures = { version = "0.3.13", default-features = false }
 uuid = { version = "0.8", features = ["v4"], default-features = false }
 mime = { version = "0.3.16", default-features = false }
 mime_guess = { version = "2.0.3", default-features = false }
+
+# exact versions to prevent "random" compilation fails 
+# caused by breaking changes in Actix libs
 actix-web = { version = "=4.0.0-beta.10", features = ["rustls"], default-features = false }
 actix-files = { version = "=0.6.0-beta.8", default-features = false }
 actix-http = { version = "=3.0.0-beta.11", default-features = false }
 actix-cors = { version = "=0.6.0-beta.3", default-features = false }
 actix-tls = { version = "=3.0.0-beta.7", default-features = false }
+actix-rt = { version = "=2.3.0", default-features = false }
+actix-router = { version = "=0.5.0-beta.2", default-features = false }
 rustls = { version = "=0.20.2", default-features = false }
 rustls-pemfile = { version = "=0.2.1", default-features = false }
-actix-rt = { version = "=2.3.0", default-features = false }
+
 trait-set = { version = "0.2.0", default-features = false }
 envy = { version = "0.4.2", default-features = false }
 serde = { version = "1.0.130", features = ["std", "derive"], default-features = false, optional = true }
@@ -27,12 +32,13 @@ parking_lot = { version = "0.11.1", default-features = false }
 env_logger = {version = "0.8.3", features = ["termcolor", "atty", "humantime"], default-features = false }
 log = { version = "0.4.14", features = ["serde"], default-features = false }
 bool_ext = { version = "0.5.1", default-features = false }
-moonlight = { path = "../moonlight", features = ["backend"] }
 enclose = { version = "1.1.8", default-features = false }
 apply = { version = "0.3.0", default-features = false }
 once_cell = { version = "1.8.0", features = ["std"], default-features = false }
 chashmap = { version = "2.2.2", default-features = false }
 async-trait = { version = "0.1.51", default-features = false }
+
+moonlight = { path = "../moonlight", features = ["backend"] }
 moon_entry_macros = { path = "../moon_entry_macros", default_features = false }
 
 [dev-dependencies]

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,13 +9,13 @@ _WARNING:_ MoonZoon is in the phase of early development and a CI pipeline / lin
 - [Rust](https://www.rust-lang.org/)
   ```bash
   rustup update stable
-  rustc -V # rustc 1.57.0 (f1edd0429 2021-11-29)
+  rustc -V # rustc 1.58.1 (db9d1b20b 2022-01-20)
   ```
 
 - [cargo-make](https://sagiegurari.github.io/cargo-make/)
   ```bash
   cargo install cargo-make --no-default-features
-  makers -V # makers 0.35.7
+  makers -V # makers 0.35.8
   ```
   - _Note_: `cargo-make` is needed only for MoonZoon development and running its examples, you don't need it for your apps.
 

--- a/examples/chat/Cargo.lock
+++ b/examples/chat/Cargo.lock
@@ -1009,6 +1009,7 @@ dependencies = [
  "actix-cors",
  "actix-files",
  "actix-http",
+ "actix-router",
  "actix-rt",
  "actix-tls",
  "actix-web",
@@ -1533,9 +1534,9 @@ checksum = "efe2374f2385cdd8755a446f80b2a646de603c9d8539ca38734879b5c71e378b"
 
 [[package]]
 name = "rustls"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5ac6078ca424dc1d3ae2328526a76787fecc7f8011f520e3276730e711fc95"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
 dependencies = [
  "log",
  "ring",

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "actix-router"
-version = "0.5.0-beta.4"
+version = "0.5.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53c1deabdbf3a8a8b9a949123edd3cafb873abd75da96b5933a8b590f9d6dc2"
+checksum = "36b95ce0d76d1aa2f98b681702807475ade0f99bd4552546a6843a966d42ea3d"
 dependencies = [
  "bytestring",
  "firestorm",
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web-codegen"
-version = "0.5.0-rc.1"
+version = "0.5.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a793e4a7bd059e06e1bc1bd9943b57a47f806de3599d2437441682292c333e"
+checksum = "30a90b7f6c2fde9a1fe3df4da758c2c3c9d620dfa3eae4da0b6925dc0a13444a"
 dependencies = [
  "actix-router",
  "proc-macro2 1.0.36",
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "firestorm"
-version = "0.5.0"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3d6188b8804df28032815ea256b6955c9625c24da7525f387a7af02fbb8f01"
+checksum = "31586bda1b136406162e381a3185a506cdfc1631708dd40cba2f6628d8634499"
 
 [[package]]
 name = "fnv"
@@ -945,6 +945,7 @@ dependencies = [
  "actix-cors",
  "actix-files",
  "actix-http",
+ "actix-router",
  "actix-rt",
  "actix-tls",
  "actix-web",


### PR DESCRIPTION
Fixing another surprising Actix breaking change causing dependency incompatibility.
Added `actix-router = { version = "=0.5.0-beta.2", default-features = false }` to Moon's `Cargo.toml`.