### PR TITLE
Make cargo-test work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,8 @@ dependencies = [
 name = "moon_entry_macros"
 version = "0.1.0"
 dependencies = [
+ "actix-web",
+ "moon",
  "quote 1.0.14",
 ]
 

--- a/crates/hsluv/Cargo.toml
+++ b/crates/hsluv/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Martin Kavík <martin@kavik.cz>"]
 edition = "2021"
 
 [dependencies]
-rust-hsluv = { version = "0.1.4", default-features = false }
+rust_hsluv = { version = "0.1.4", default-features = false, package = "rust-hsluv" }
 hsluv_macro = { path = "../hsluv_macro", default-features = false, optional = true }
 
 [features]

--- a/crates/hsluv/src/lib.rs
+++ b/crates/hsluv/src/lib.rs
@@ -1,4 +1,4 @@
-use hsluv::hsluv_to_rgb;
+use rust_hsluv::hsluv_to_rgb;
 
 #[cfg(feature = "hsluv_macro")]
 pub use hsluv_macro::hsluv;

--- a/crates/moon_entry_macros/Cargo.toml
+++ b/crates/moon_entry_macros/Cargo.toml
@@ -9,3 +9,7 @@ proc-macro = true
 
 [dependencies]
 quote = { version = "1.0", default-features = false }
+
+[dev-dependencies]
+moon = {path = "../moon"}
+actix-web = { version = "=4.0.0-beta.10", features = ["rustls"], default-features = false }


### PR DESCRIPTION
## Description
The goal is to make `cargo test` run successfully without errors. 
- Error 1 is caused by rlib name conflict between crate hsluv and dependency rust-hsluv. Resolved by utilizing [cargo dependency renaming](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml).
- Error 2 is caused by missing dependencies when compiling doc examples. Resolved by adding dev dependencies.

## Issues
Fixes #63 

## Testing
- No errors returned from `cargo test`
- Examples build and run successfully
