### PR TITLE
Profiling + TRANSPARENT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,13 +478,32 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
 dependencies = [
+ "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -924,12 +943,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1338,6 +1354,7 @@ dependencies = [
  "brotli",
  "cargo_metadata",
  "cfg-if 1.0.0",
+ "clap",
  "const_format",
  "fehler",
  "flate2",
@@ -1349,7 +1366,6 @@ dependencies = [
  "rcgen",
  "reqwest",
  "serde",
- "structopt",
  "tar",
  "tokio",
  "toml",
@@ -1482,6 +1498,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2258,28 +2283,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "structopt"
-version = "0.3.25"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.84",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -2338,12 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
@@ -2582,18 +2586,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/mzoon/Cargo.toml
+++ b/crates/mzoon/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Martin Kavík <martin@kavik.cz>"]
 edition = "2021"
 
 [dependencies]
-structopt = { version = "0.3", default-features = false }
+clap = { version = "3.1.0", features = ["std", "color", "suggestions", "derive"], default-features = false }
 toml = { version = "0.5", default-features = false }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 notify = { version = "=5.0.0-pre.9", default-features = false }

--- a/crates/mzoon/src/build_frontend.rs
+++ b/crates/mzoon/src/build_frontend.rs
@@ -2,6 +2,7 @@ use crate::helper::{
     visit_files, AsyncReadToVec, BrotliFileCompressor, FileCompressor, GzipFileCompressor,
 };
 use crate::wasm_pack::{build_with_wasm_pack, check_or_install_wasm_pack};
+use crate::BuildMode;
 use anyhow::{Context, Error};
 use const_format::concatcp;
 use fehler::throws;
@@ -16,11 +17,11 @@ use uuid::Uuid;
 // -- public --
 
 #[throws]
-pub async fn build_frontend(release: bool, cache_busting: bool) {
+pub async fn build_frontend(build_mode: BuildMode, cache_busting: bool) {
     println!("Building frontend...");
     check_or_install_wasm_pack().await?;
     remove_pkg().await?;
-    build_with_wasm_pack(release).await?;
+    build_with_wasm_pack(build_mode).await?;
 
     let build_id = Uuid::new_v4().as_u128();
     let (wasm_file_path, js_file_path, _) = try_join!(
@@ -28,7 +29,7 @@ pub async fn build_frontend(release: bool, cache_busting: bool) {
         rename_js_file(build_id, cache_busting),
         write_build_id(build_id),
     )?;
-    if release {
+    if build_mode.is_not_dev() {
         compress_pkg(wasm_file_path.as_ref(), js_file_path.as_ref()).await?;
     }
     println!("Frontend built");

--- a/crates/mzoon/src/command/build.rs
+++ b/crates/mzoon/src/command/build.rs
@@ -2,14 +2,15 @@ use crate::build_backend::build_backend;
 use crate::build_frontend::build_frontend;
 use crate::config::Config;
 use crate::set_env_vars::set_env_vars;
+use crate::BuildMode;
 use anyhow::Error;
 use fehler::throws;
 
 #[throws]
-pub async fn build(release: bool) {
+pub async fn build(build_mode: BuildMode) {
     let config = Config::load_from_moonzoon_toml().await?;
-    set_env_vars(&config, release);
+    set_env_vars(&config, build_mode);
 
-    build_frontend(release, config.cache_busting).await?;
-    build_backend(release, config.https).await?;
+    build_frontend(build_mode, config.cache_busting).await?;
+    build_backend(build_mode, config.https).await?;
 }

--- a/crates/mzoon/src/command/start.rs
+++ b/crates/mzoon/src/command/start.rs
@@ -28,7 +28,7 @@ pub async fn start(build_mode: BuildMode, open: bool) {
 #[throws]
 async fn build_and_watch_frontend(config: &Config, build_mode: BuildMode) -> FrontendWatcher {
     if let Err(error) = build_frontend(build_mode, config.cache_busting).await {
-        eprintln!("{}", error);
+        eprintln!("{error:#}");
     }
     FrontendWatcher::start(&config, build_mode, DEBOUNCE_TIME).await?
 }
@@ -49,12 +49,12 @@ async fn build_run_and_watch_backend(
 #[throws(as Option)]
 async fn build_and_run_backend(config: &Config, build_mode: BuildMode) -> Child {
     if let Err(error) = build_backend(build_mode, config.https).await {
-        eprintln!("{}", error);
+        eprintln!("{error:#}");
         None?;
     }
     match run_backend(build_mode) {
         Err(error) => {
-            eprintln!("{}", error);
+            eprintln!("{error:#}");
             None?
         }
         Ok(server) => server,
@@ -68,6 +68,6 @@ fn open_in_browser(config: &Config) {
         protocol = if config.https { "https" } else { "http" },
         port = config.port
     );
-    println!("Open {} in the default web browser", url);
+    println!("Open {url} in the default web browser");
     open::that(url).context("Failed to open the URL in the browser")?;
 }

--- a/crates/mzoon/src/main.rs
+++ b/crates/mzoon/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Error;
+use clap::Parser;
 use fehler::throws;
-use structopt::StructOpt;
 
 mod build_backend;
 mod build_frontend;
@@ -12,34 +12,71 @@ mod set_env_vars;
 mod wasm_pack;
 mod watcher;
 
-#[derive(Debug, StructOpt)]
-enum Opt {
+/// MoonZoon CLI <http://MoonZoon.rs>
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+enum Args {
     New {
         project_name: String,
-        #[structopt(short, long)]
+        #[clap(short, long)]
         here: bool,
     },
     Start {
-        #[structopt(short, long)]
+        #[clap(short, long)]
         release: bool,
-        #[structopt(short, long)]
+        #[clap(short, long)]
+        profiling: bool,
+        #[clap(short, long)]
         open: bool,
     },
     Build {
-        #[structopt(short, long)]
+        #[clap(short, long)]
         release: bool,
+        #[clap(short, long)]
+        profiling: bool,
     },
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum BuildMode {
+    Dev,
+    Release,
+    Profiling,
+}
+
+impl BuildMode {
+    fn new(release: bool, profiling: bool) -> Self {
+        match (release, profiling) {
+            (false, false) => Self::Dev,
+            (true, false) => Self::Release,
+            (_, true) => Self::Profiling,
+        }
+    }
+
+    fn is_dev(&self) -> bool {
+        matches!(self, Self::Dev)
+    }
+
+    fn is_not_dev(&self) -> bool {
+        !self.is_dev()
+    }
 }
 
 #[throws]
 #[tokio::main]
 async fn main() {
-    let opt = Opt::from_args();
-    println!("{:?}", opt);
+    let args = Args::parse();
+    println!("{:?}", args);
 
-    match opt {
-        Opt::New { project_name, here } => command::new(project_name, here).await?,
-        Opt::Start { release, open } => command::start(release, open).await?,
-        Opt::Build { release } => command::build(release).await?,
+    match args {
+        Args::New { project_name, here } => command::new(project_name, here).await?,
+        Args::Start {
+            release,
+            profiling,
+            open,
+        } => command::start(BuildMode::new(release, profiling), open).await?,
+        Args::Build { release, profiling } => {
+            command::build(BuildMode::new(release, profiling)).await?
+        }
     }
 }

--- a/crates/mzoon/src/run_backend.rs
+++ b/crates/mzoon/src/run_backend.rs
@@ -1,3 +1,4 @@
+use crate::BuildMode;
 use anyhow::{Context, Error};
 use apply::{Also, Apply};
 use cargo_metadata::MetadataCommand;
@@ -5,13 +6,19 @@ use fehler::throws;
 use tokio::process::{Child, Command};
 
 #[throws]
-pub fn run_backend(release: bool) -> Child {
+pub fn run_backend(build_mode: BuildMode) -> Child {
     println!("Run backend");
     MetadataCommand::new()
         .no_deps()
         .exec()?
         .target_directory
-        .also(|directory| directory.push(if release { "release" } else { "debug" }))
+        .also(|directory| {
+            directory.push(if build_mode.is_dev() {
+                "debug"
+            } else {
+                "release"
+            })
+        })
         .also(|directory| directory.push("backend"))
         .apply(Command::new)
         .spawn()

--- a/crates/mzoon/src/set_env_vars.rs
+++ b/crates/mzoon/src/set_env_vars.rs
@@ -1,7 +1,7 @@
-use crate::config::Config;
+use crate::{config::Config, BuildMode};
 use std::env;
 
-pub fn set_env_vars(config: &Config, release: bool) {
+pub fn set_env_vars(config: &Config, build_mode: BuildMode) {
     // port = 8443
     env::set_var("PORT", config.port.to_string());
     // https = true
@@ -21,5 +21,5 @@ pub fn set_env_vars(config: &Config, release: bool) {
     // origins = ["*", "https://example.com"]
     env::set_var("CORS_ORIGINS", config.cors.origins.join(","));
 
-    env::set_var("COMPRESSED_PKG", release.to_string());
+    env::set_var("COMPRESSED_PKG", build_mode.is_not_dev().to_string());
 }

--- a/crates/mzoon/src/wasm_pack.rs
+++ b/crates/mzoon/src/wasm_pack.rs
@@ -10,7 +10,8 @@ use std::path::PathBuf;
 use tar::Archive;
 use tokio::process::Command;
 
-const VERSION: &str = "0.10.2";
+// @TODO Update once https://github.com/rustwasm/wasm-pack/issues/1097 is resolved.
+const VERSION: &str = "0.10.1";
 
 // -- public --
 

--- a/crates/mzoon/src/wasm_pack.rs
+++ b/crates/mzoon/src/wasm_pack.rs
@@ -1,4 +1,4 @@
-use crate::helper::download;
+use crate::{helper::download, BuildMode};
 use anyhow::{anyhow, Context, Error};
 use apply::Apply;
 use bool_ext::BoolExt;
@@ -57,7 +57,7 @@ pub async fn check_or_install_wasm_pack() {
 }
 
 #[throws]
-pub async fn build_with_wasm_pack(release: bool) {
+pub async fn build_with_wasm_pack(build_mode: BuildMode) {
     let mut args = vec![
         "--log-level",
         "warn",
@@ -67,8 +67,14 @@ pub async fn build_with_wasm_pack(release: bool) {
         "web",
         "--no-typescript",
     ];
-    if !release {
-        args.push("--dev");
+    // https://rustwasm.github.io/docs/wasm-pack/commands/build.html#profile
+    match build_mode {
+        BuildMode::Dev => args.push("--dev"),
+        // @TODO does it work? See
+        // https://github.com/rustwasm/wasm-pack/blob/4ae6306570a0011246c39c8028a4f11a4236f54b/src/build/mod.rs#L92-L99
+        // and https://github.com/rustwasm/wasm-pack/issues/797
+        BuildMode::Profiling => args.push("--profiling"),
+        BuildMode::Release => (),
     }
     Command::new("frontend/wasm-pack")
         .args(&args)

--- a/crates/mzoon/src/watcher/backend_watcher.rs
+++ b/crates/mzoon/src/watcher/backend_watcher.rs
@@ -2,6 +2,7 @@ use super::project_watcher::ProjectWatcher;
 use crate::build_backend::build_backend;
 use crate::config::Config;
 use crate::run_backend::run_backend;
+use crate::BuildMode;
 use anyhow::{Context, Error, Result};
 use fehler::throws;
 use parking_lot::Mutex;
@@ -19,7 +20,7 @@ impl BackendWatcher {
     #[throws]
     pub async fn start(
         config: &Config,
-        release: bool,
+        build_mode: BuildMode,
         debounce_time: Duration,
         server: Option<Child>,
     ) -> Self {
@@ -28,7 +29,12 @@ impl BackendWatcher {
                 .context("Failed to start the backend project watcher")?;
         Self {
             watcher,
-            task: spawn(on_change(debounced_receiver, release, config.https, server)),
+            task: spawn(on_change(
+                debounced_receiver,
+                build_mode,
+                config.https,
+                server,
+            )),
         }
     }
 
@@ -42,7 +48,7 @@ impl BackendWatcher {
 #[throws]
 async fn on_change(
     mut receiver: UnboundedReceiver<()>,
-    release: bool,
+    build_mode: BuildMode,
     https: bool,
     server: Option<Child>,
 ) {
@@ -59,7 +65,7 @@ async fn on_change(
             let _ = server.kill().await;
         }
 
-        build_task = Some(spawn(build_and_run(Arc::clone(&server), release, https)));
+        build_task = Some(spawn(build_and_run(Arc::clone(&server), build_mode, https)));
     }
 
     if let Some(build_task) = build_task.take() {
@@ -67,11 +73,11 @@ async fn on_change(
     }
 }
 
-async fn build_and_run(server: Arc<Mutex<Option<Child>>>, release: bool, https: bool) {
-    if let Err(error) = build_backend(release, https).await {
+async fn build_and_run(server: Arc<Mutex<Option<Child>>>, build_mode: BuildMode, https: bool) {
+    if let Err(error) = build_backend(build_mode, https).await {
         return eprintln!("{}", error);
     }
-    match run_backend(release) {
+    match run_backend(build_mode) {
         Ok(backend) => *server.lock() = Some(backend),
         Err(error) => eprintln!("{}", error),
     }

--- a/crates/zoon/src/style/named_color.rs
+++ b/crates/zoon/src/style/named_color.rs
@@ -6,6 +6,8 @@ macro_rules! color {
     };
 }
 
+pub static TRANSPARENT: HSLuv = hsluv!(0, 0, 0, 0);
+
 // The palette based on https://tailwindcss.com/docs/customizing-colors
 
 color!(GRAY_0 => 235.5, 22.1, 98.2);


### PR DESCRIPTION
Resolves #66

- The crate `structopt` replaced with `clap` + refactored `mzoon` code.
- Added command option `mzoon --profiling` (or `-p`).
- Added `named_color::TRANSPARENT`.