### PR TITLE
url_encode LitStr route segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,6 +1960,7 @@ dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
  "syn 1.0.84",
+ "urlencoding",
 ]
 
 [[package]]
@@ -2624,6 +2625,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
 
 [[package]]
 name = "uuid"

--- a/crates/mzoon/src/wasm_pack.rs
+++ b/crates/mzoon/src/wasm_pack.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use tar::Archive;
 use tokio::process::Command;
 
-const VERSION: &str = "0.10.2";
+const VERSION: &str = "0.10.1";
 
 // -- public --
 

--- a/crates/route_macro/Cargo.toml
+++ b/crates/route_macro/Cargo.toml
@@ -11,3 +11,4 @@ proc-macro = true
 syn = { version = "1.0", default-features = false }
 quote = { version = "1.0", default-features = false }
 proc-macro2 = { version = "1.0", default-features = false }
+urlencoding = { version = "2.1.0", default-features = false }

--- a/crates/route_macro/src/lib.rs
+++ b/crates/route_macro/src/lib.rs
@@ -321,9 +321,7 @@ fn assemble_url_template(segments: &[RouteSegment]) -> LitStr {
     for segment in segments {
         url_template.push('/');
         match segment {
-            RouteSegment::LitStr(lit_str) => {
-                url_template.push_str(&url_encode(&lit_str.value()))
-            },
+            RouteSegment::LitStr(lit_str) => url_template.push_str(&url_encode(&lit_str.value())),
             RouteSegment::Ident(ident) => {
                 url_template.push('{');
                 url_template.push_str(&ident.to_string());

--- a/crates/route_macro/src/lib.rs
+++ b/crates/route_macro/src/lib.rs
@@ -8,6 +8,7 @@ use syn::{
     spanned::Spanned,
     Arm, Attribute, ExprIf, FieldValue, Ident, ItemEnum, ItemFn, ItemImpl, LitStr, Token, Variant,
 };
+use urlencoding::encode as url_encode;
 
 // @TODO rewrite panics/expects/unwraps to `syn::Error`s (see hsluv_macro)?
 
@@ -320,7 +321,9 @@ fn assemble_url_template(segments: &[RouteSegment]) -> LitStr {
     for segment in segments {
         url_template.push('/');
         match segment {
-            RouteSegment::LitStr(lit_str) => url_template.push_str(&lit_str.value()),
+            RouteSegment::LitStr(lit_str) => {
+                url_template.push_str(&url_encode(&lit_str.value()))
+            },
             RouteSegment::Ident(ident) => {
                 url_template.push('{');
                 url_template.push_str(&ident.to_string());

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,13 +9,13 @@ _WARNING:_ MoonZoon is in the phase of early development and a CI pipeline / lin
 - [Rust](https://www.rust-lang.org/)
   ```bash
   rustup update stable
-  rustc -V # rustc 1.58.1 (db9d1b20b 2022-01-20)
+  rustc -V # rustc 1.59.0 (9d1b2106e 2022-02-23)
   ```
 
 - [cargo-make](https://sagiegurari.github.io/cargo-make/)
   ```bash
   cargo install cargo-make --no-default-features
-  makers -V # makers 0.35.8
+  makers -V # makers 0.35.9
   ```
   - _Note_: `cargo-make` is needed only for MoonZoon development and running its examples, you don't need it for your apps.
 

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -1399,6 +1399,7 @@ dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
  "syn 1.0.84",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1829,6 +1830,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
 
 [[package]]
 name = "uuid"

--- a/examples/pages/Cargo.lock
+++ b/examples/pages/Cargo.lock
@@ -950,6 +950,7 @@ dependencies = [
  "actix-cors",
  "actix-files",
  "actix-http",
+ "actix-router",
  "actix-rt",
  "actix-tls",
  "actix-web",
@@ -1424,6 +1425,7 @@ dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
  "syn 1.0.73",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1443,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5ac6078ca424dc1d3ae2328526a76787fecc7f8011f520e3276730e711fc95"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
 dependencies = [
  "log",
  "ring",
@@ -1876,6 +1878,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
 
 [[package]]
 name = "uuid"

--- a/examples/pages/frontend/src/calc_page.rs
+++ b/examples/pages/frontend/src/calc_page.rs
@@ -1,7 +1,7 @@
 use crate::router::Route;
 use evalexpr::eval;
 use std::fmt;
-use zoon::{*, named_color::*};
+use zoon::{named_color::*, *};
 
 // ------ ------
 //     Types

--- a/examples/pages/frontend/src/header.rs
+++ b/examples/pages/frontend/src/header.rs
@@ -1,5 +1,5 @@
 use crate::{app, router::Route};
-use zoon::{*, named_color::*};
+use zoon::{named_color::*, *};
 
 // ------ ------
 //     View
@@ -24,8 +24,7 @@ pub fn header() -> impl Element {
 fn back_button() -> impl Element {
     let (hovered, hovered_signal) = Mutable::new_and_signal(false);
     Button::new()
-        .s(Background::new()
-            .color_signal(hovered_signal.map_bool(|| GREEN_7, || GREEN_8)))
+        .s(Background::new().color_signal(hovered_signal.map_bool(|| GREEN_7, || GREEN_8)))
         .s(Padding::new().x(7).y(4))
         .on_hovered_change(move |is_hovered| hovered.set(is_hovered))
         .label("< Back")
@@ -42,8 +41,7 @@ fn link(label: &str, route: Route) -> impl Element {
 fn log_out_button(name: &str) -> impl Element {
     let (hovered, hovered_signal) = Mutable::new_and_signal(false);
     Button::new()
-        .s(Background::new()
-            .color_signal(hovered_signal.map_bool(|| RED_7, || RED_8)))
+        .s(Background::new().color_signal(hovered_signal.map_bool(|| RED_7, || RED_8)))
         .s(Padding::new().x(7).y(4))
         .on_hovered_change(move |is_hovered| hovered.set(is_hovered))
         .label(format!("Log out {}", name))

--- a/examples/pages/frontend/src/login_page.rs
+++ b/examples/pages/frontend/src/login_page.rs
@@ -1,5 +1,5 @@
 use crate::app;
-use zoon::{*, named_color::*};
+use zoon::{named_color::*, *};
 
 // ------ ------
 //    States
@@ -42,8 +42,7 @@ fn name_input() -> impl Element {
 fn log_in_button() -> impl Element {
     let (hovered, hovered_signal) = Mutable::new_and_signal(false);
     Button::new()
-        .s(Background::new()
-            .color_signal(hovered_signal.map_bool(|| GREEN_7, || GREEN_8)))
+        .s(Background::new().color_signal(hovered_signal.map_bool(|| GREEN_7, || GREEN_8)))
         .s(Padding::all(7))
         .on_hovered_change(move |is_hovered| hovered.set(is_hovered))
         .label("Log in")

--- a/examples/pages/frontend/src/report_page.rs
+++ b/examples/pages/frontend/src/report_page.rs
@@ -1,6 +1,6 @@
 use crate::{app, router::Route};
 use std::borrow::Cow;
-use zoon::{*, named_color::*};
+use zoon::{named_color::*, *};
 
 const DAILY: &str = "daily";
 const WEEKLY: &str = "weekly";


### PR DESCRIPTION
- url_encode `LitStr` route segments (context on [Discord](https://discord.com/channels/797429007683158046/797429007683158051/946784132141318284))
- downgrade `wasm-pack` to `0.10.1` to fix compilation problem on Windows 