### PR TITLE
RawEl::inner_markup_signal

### DIFF
--- a/examples/markup/Cargo.lock
+++ b/examples/markup/Cargo.lock
@@ -1467,6 +1467,7 @@ dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
  "syn 1.0.84",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1903,6 +1904,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
 
 [[package]]
 name = "uuid"

--- a/examples/markup/frontend/src/lib.rs
+++ b/examples/markup/frontend/src/lib.rs
@@ -55,8 +55,27 @@ fn markdown_to_html(markdown: &str) -> String {
 }
 
 fn markdown_example() -> impl Element {
-    let html = markdown_to_html(include_str!("markdown_page.md"));
-    RawHtmlEl::new("div").inner_markup(html)
+    Column::new()
+        .item(counter_info())
+        .item(divider())
+        .item(html_page())
+}
+
+fn counter_info() -> impl Element {
+    fn content(counter_value: i32) -> String {
+        markdown_to_html(&format!("Counter value: _**{counter_value}**_"))
+    }
+    RawHtmlEl::new("div").inner_markup_signal(counter().signal().map(content))
+}
+
+fn divider() -> impl Element {
+    RawHtmlEl::from_markup(markdown_to_html("---"))
+        .unwrap_throw()
+        .style("width", "100%")
+}
+
+fn html_page() -> impl Element {
+    RawHtmlEl::new("div").inner_markup(markdown_to_html(include_str!("markdown_page.md")))
 }
 
 // ------ MAUD ------


### PR DESCRIPTION
- Added the method `RawEl::inner_markup_signal`.
- Updated the `markup` example.