### PR TITLE
Example `layers` update, `LayerIndex` update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
         // "examples/custom_config/Cargo.toml",
         // "examples/custom_http_client/Cargo.toml",
         // "examples/js-framework-benchmark/keyed/Cargo.toml",
-        // "examples/layers/Cargo.toml",
+        "examples/layers/Cargo.toml",
         // "examples/markup/Cargo.toml",
         // "examples/pages/Cargo.toml",
         // "examples/paragraph/Cargo.toml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
         // "examples/custom_config/Cargo.toml",
         // "examples/custom_http_client/Cargo.toml",
         // "examples/js-framework-benchmark/keyed/Cargo.toml",
-        "examples/layers/Cargo.toml",
+        // "examples/layers/Cargo.toml",
         // "examples/markup/Cargo.toml",
         // "examples/pages/Cargo.toml",
         // "examples/paragraph/Cargo.toml",

--- a/crates/zoon/src/style/layer_index.rs
+++ b/crates/zoon/src/style/layer_index.rs
@@ -7,7 +7,12 @@ pub struct LayerIndex<'a> {
 }
 
 impl<'a> LayerIndex<'a> {
-    pub fn new(index: u32) -> Self {
+    // Google says we can't use `i32::MIN/MAX` on all browsers directly, don't know why
+    const MAX_VALUE_OFFSET: i32 = 9;
+    pub const MIN_VALUE: i32 = i32::MIN + Self::MAX_VALUE_OFFSET;
+    pub const MAX_VALUE: i32 = i32::MAX - Self::MAX_VALUE_OFFSET;
+
+    pub fn new(index: i32) -> Self {
         let mut this = Self::default();
         this.static_css_props
             .insert("z-index", index.into_cow_str());
@@ -15,7 +20,7 @@ impl<'a> LayerIndex<'a> {
     }
 
     pub fn with_signal(
-        index: impl Signal<Item = impl Into<Option<u32>>> + Unpin + 'static,
+        index: impl Signal<Item = impl Into<Option<i32>>> + Unpin + 'static,
     ) -> Self {
         let mut this = Self::default();
         let index = index.map(|index| index.into());

--- a/examples/layers/Cargo.lock
+++ b/examples/layers/Cargo.lock
@@ -571,6 +571,7 @@ dependencies = [
 name = "frontend"
 version = "0.1.0"
 dependencies = [
+ "strum",
  "wasm-bindgen-test",
  "zoon",
 ]
@@ -729,6 +730,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1506,6 +1513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "rusty_ulid"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1685,28 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
+ "syn 1.0.84",
+]
+
+[[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "rustversion",
  "syn 1.0.84",
 ]
 

--- a/examples/layers/backend/src/main.rs
+++ b/examples/layers/backend/src/main.rs
@@ -1,12 +1,29 @@
 use moon::*;
 
 async fn frontend() -> Frontend {
+    // @TODO replace CSS animation with a future Zoon animation API
+    // @TODO inspiration: https://github.com/MoonZoon/MoonZoon/blob/main/docs/frontend.md#faq
     Frontend::new().title("Layers example").append_to_head(
         "
         <style>
             html {
                 background-color: black;
                 color: lightgray;
+            }
+
+            .rectangle {
+                animation-name: stretch;
+                animation-duration: 2.0s;
+                animation-timing-function: ease-out;
+                animation-direction: alternate;
+                animation-iteration-count: infinite;
+                animation-play-state: running;
+            }
+      
+            @keyframes stretch {
+                100% {
+                    transform: scale(1.2);
+                }
             }
         </style>",
     )

--- a/examples/layers/frontend/Cargo.toml
+++ b/examples/layers/frontend/Cargo.toml
@@ -17,6 +17,7 @@ wasm-bindgen-test = "0.3.19"
 
 [dependencies]
 zoon = { path = "../../../crates/zoon" }
+strum = { version = "0.24.0", default-features = false, features = ["derive"] }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ['-Os']

--- a/examples/layers/frontend/src/lib.rs
+++ b/examples/layers/frontend/src/lib.rs
@@ -36,10 +36,10 @@ fn bring_to_front(layer_id: LayerId) {
 //    Signals
 // ------ ------
 
-fn layer_index(layer_id: LayerId) -> impl Signal<Item = u32> {
+fn layer_index(layer_id: LayerId) -> impl Signal<Item = i32> {
     layer_order()
         .signal_ref(move |layers| {
-            layers.iter().position(|id| id == &layer_id).unwrap_throw() as u32
+            layers.iter().position(|id| id == &layer_id).unwrap_throw() as i32
         })
         .dedupe()
 }

--- a/examples/layers/frontend/src/lib.rs
+++ b/examples/layers/frontend/src/lib.rs
@@ -63,6 +63,7 @@ fn rectangle(rectangle: Rectangle) -> impl Element {
     let (color, align) = rectangle.color_and_align();
 
     El::new()
+        .update_raw_el(|el| el.class("rectangle"))
         .s(Width::new(100))
         .s(Height::new(100))
         .s(RoundedCorners::all(15))


### PR DESCRIPTION
- Added `const`s `LayerIndex::MIN_VALUE/MAX_VALUE`.
- `LayerIndex::new/with_signal` accept `i32` instead of `u32`.
- Added the "pulsing rectangle" CSS animation to the `layers` example. (It'll be replaced with native Zoon animation API.)
- The example `layers` refactored - the rectangle ordering is managed with the help of `MutableVec` instead of `LayerIndex`.