### PR TITLE
Fix Connection up_msg_handler URL

### DIFF
--- a/crates/zoon/src/connection.rs
+++ b/crates/zoon/src/connection.rs
@@ -53,7 +53,7 @@ impl<UMsg: Serialize, DMsg: DeserializeOwned> Connection<UMsg, DMsg> {
 
         // ---- Request ----
         let request =
-            Request::new_with_str_and_init("_api/up_msg_handler", &request_init).unwrap_throw();
+            Request::new_with_str_and_init("/_api/up_msg_handler", &request_init).unwrap_throw();
 
         // ---- Headers ----
         let cor_id = CorId::new();


### PR DESCRIPTION
- Fixed `UpMsg` sending when the user has been redirected to a non-root url.

Thanks @osain-az for reporting the bug and creating an example to reproduce it!