### PR TITLE
Rust 1.62.0, enum defaults

### DIFF
--- a/crates/zoon/src/style/height.rs
+++ b/crates/zoon/src/style/height.rs
@@ -22,19 +22,12 @@ enum CssName {
     MaxHeight,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, EnumIter, IntoStaticStr)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, EnumIter, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 enum HeightMode {
+    #[default]
     ExactHeight,
     FillHeight,
-}
-
-// @TODO remove (in the entire codebase) once `derive_default_enum` is stable
-// https://github.com/rust-lang/rust/issues/87517
-impl Default for HeightMode {
-    fn default() -> Self {
-        Self::ExactHeight
-    }
 }
 
 impl<'a> Height<'a> {

--- a/crates/zoon/src/style/width.rs
+++ b/crates/zoon/src/style/width.rs
@@ -21,19 +21,12 @@ enum CssName {
     MaxWidth,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, EnumIter, IntoStaticStr)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, EnumIter, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 enum WidthMode {
+    #[default]
     ExactWidth,
     FillWidth,
-}
-
-// @TODO derive `Default` for `WidthMode` and other enums once possible.
-// https://rust-lang.github.io/rfcs/3107-derive-default-enum.html
-impl Default for WidthMode {
-    fn default() -> Self {
-        Self::ExactWidth
-    }
 }
 
 impl<'a> Width<'a> {

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,7 +9,7 @@ _WARNING:_ MoonZoon is in the phase of early development and a CI pipeline / lin
 - [Rust](https://www.rust-lang.org/)
   ```bash
   rustup update stable
-  rustc -V # rustc 1.61.0 (fe5b13d68 2022-05-18)
+  rustc -V # rustc 1.62.0 (a8314ef7d 2022-06-27)
   ```
 
 - [cargo-make](https://sagiegurari.github.io/cargo-make/)

--- a/examples/time_tracker/shared/src/time_blocks.rs
+++ b/examples/time_tracker/shared/src/time_blocks.rs
@@ -19,18 +19,13 @@ pub struct TimeBlock {
     pub invoice: Option<Invoice>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, Eq)]
 #[serde(crate = "serde")]
 pub enum TimeBlockStatus {
     NonBillable,
+    #[default]
     Unpaid,
     Paid,
-}
-
-impl Default for TimeBlockStatus {
-    fn default() -> Self {
-        Self::Unpaid
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
- Derive `Default` for `enum`s.
- Adapt to Rust 1.62.0.