### PR TITLE
feat(link)!: Added new tab configuration for noopener, norefferer and nofollow

### DIFF
--- a/crates/zoon/src/element.rs
+++ b/crates/zoon/src/element.rs
@@ -25,7 +25,7 @@ pub mod label;
 pub use label::Label;
 
 pub mod link;
-pub use link::Link;
+pub use link::{Link, NewTab};
 
 pub mod paragraph;
 pub use paragraph::Paragraph;

--- a/crates/zoon/src/element/link.rs
+++ b/crates/zoon/src/element/link.rs
@@ -7,6 +7,28 @@ use std::{iter, marker::PhantomData};
 
 make_flags!(Label, To);
 
+pub struct NewTab {
+    refer: bool,
+    follow: bool,
+}
+
+impl NewTab {
+    pub fn new() -> Self {
+        Self {
+            refer: false,
+            follow: true,
+        }
+    }
+
+    pub fn refer(&mut self, value: bool) {
+        self.refer = value;
+    }
+
+    pub fn follow(&mut self, value: bool) {
+        self.follow = value;
+    }
+}
+
 pub struct Link<LabelFlag, ToFlag, RE: RawEl> {
     raw_el: RE,
     flags: PhantomData<(LabelFlag, ToFlag)>,
@@ -131,9 +153,20 @@ impl<'a, LabelFlag, ToFlag, RE: RawEl> Link<LabelFlag, ToFlag, RE> {
         self.into_type()
     }
 
-    pub fn new_tab(mut self) -> Link<LabelFlag, ToFlag, RE> {
-        self.raw_el = self.raw_el.attr("target", "_blank")
-            .attr("rel", "noopener noreferrer");
+    pub fn new_tab(mut self, new_tab: NewTab) -> Link<LabelFlag, ToFlag, RE> {
+        // @TODO remove 'noopener' once all browsers add it implicitly with '_blank'
+        let mut rel = vec!["noopener"];
+        if !new_tab.refer {
+            rel.push("noreferrer");
+        }
+        if !new_tab.follow {
+            rel.push("nofollow");
+        }
+
+        self.raw_el = self
+            .raw_el
+            .attr("target", "_blank")
+            .attr("rel", rel.join(" ").as_str());
         self.into_type()
     }
 

--- a/crates/zoon/src/element/link.rs
+++ b/crates/zoon/src/element/link.rs
@@ -132,7 +132,8 @@ impl<'a, LabelFlag, ToFlag, RE: RawEl> Link<LabelFlag, ToFlag, RE> {
     }
 
     pub fn new_tab(mut self) -> Link<LabelFlag, ToFlag, RE> {
-        self.raw_el = self.raw_el.attr("target", "_blank");
+        self.raw_el = self.raw_el.attr("target", "_blank")
+            .attr("rel", "noopener noreferrer");
         self.into_type()
     }
 

--- a/examples/time_tracker/frontend/src/time_blocks_page/view.rs
+++ b/examples/time_tracker/frontend/src/time_blocks_page/view.rs
@@ -459,6 +459,6 @@ fn link_button(invoice: Arc<super::Invoice>) -> impl Element {
         .s(RoundedCorners::all_max())
         .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))
         .to_signal(invoice.url.signal_cloned())
-        .new_tab()
+        .new_tab(NewTab::new())
         .label(app::icon_open_in_new())
 }

--- a/examples/todomvc/frontend/src/app/view.rs
+++ b/examples/todomvc/frontend/src/app/view.rs
@@ -314,7 +314,7 @@ fn author_link() -> impl Element {
         .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))
         .label("Martin Kavík")
         .to("https://github.com/MartinKavik")
-        .new_tab()
+        .new_tab(NewTab::new())
 }
 
 fn todomvc_link() -> impl Element {
@@ -324,5 +324,5 @@ fn todomvc_link() -> impl Element {
         .on_hovered_change(move |is_hovered| hovered.set_neq(is_hovered))
         .label("TodoMVC")
         .to("http://todomvc.com")
-        .new_tab()
+        .new_tab(NewTab::new())
 }


### PR DESCRIPTION
For security reasons noopener and noreferrer should be used for links with target _blank.