### PR TITLE
Changed EventOptions, updated events + handlers

### DIFF
--- a/crates/zoon/src/element.rs
+++ b/crates/zoon/src/element.rs
@@ -4,7 +4,7 @@ use std::iter;
 // -- modules --
 
 pub mod button;
-pub use button::Button;
+pub use button::{Button, ButtonPressEvent};
 
 pub mod canvas;
 pub use canvas::Canvas;

--- a/crates/zoon/src/element/ability/keyboard_event_aware.rs
+++ b/crates/zoon/src/element/ability/keyboard_event_aware.rs
@@ -43,6 +43,10 @@ impl KeyboardEvent {
             f()
         }
     }
+
+    pub fn pass_to_parent(&self, pass: bool) {
+        self.raw_event.pass_to_parent(pass);
+    }
 }
 
 // ------ RawKeyboardEvent ------
@@ -50,6 +54,16 @@ impl KeyboardEvent {
 #[derive(Clone)]
 pub enum RawKeyboardEvent {
     KeyDown(Arc<events::KeyDown>),
+}
+
+impl RawKeyboardEvent {
+    pub fn pass_to_parent(&self, pass: bool) {
+        if not(pass) {
+            match self {
+                Self::KeyDown(event) => event.stop_propagation(),
+            }
+        }
+    }
 }
 
 // ------ Key ------

--- a/crates/zoon/src/element/ability/keyboard_event_aware.rs
+++ b/crates/zoon/src/element/ability/keyboard_event_aware.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use std::borrow::Borrow;
+use std::{borrow::Borrow, sync::Arc};
 
 // ------ KeyboardEventAware ------
 
@@ -17,7 +17,7 @@ pub trait KeyboardEventAware: UpdateRawEl + Sized {
             raw_el.event_handler_with_options(options, move |event: events::KeyDown| {
                 let keyboard_event = KeyboardEvent {
                     key: Key::from(event.key()),
-                    raw_event: RawKeyboardEvent::KeyDown(event),
+                    raw_event: RawKeyboardEvent::KeyDown(Arc::new(event)),
                 };
                 handler(keyboard_event);
             })
@@ -27,6 +27,7 @@ pub trait KeyboardEventAware: UpdateRawEl + Sized {
 
 // ------ KeyboardEvent ------
 
+#[derive(Clone)]
 pub struct KeyboardEvent {
     key: Key,
     pub raw_event: RawKeyboardEvent,
@@ -46,13 +47,14 @@ impl KeyboardEvent {
 
 // ------ RawKeyboardEvent ------
 
+#[derive(Clone)]
 pub enum RawKeyboardEvent {
-    KeyDown(events::KeyDown),
+    KeyDown(Arc<events::KeyDown>),
 }
 
 // ------ Key ------
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub enum Key {
     Enter,
     Escape,

--- a/crates/zoon/src/element/ability/mouse_event_aware.rs
+++ b/crates/zoon/src/element/ability/mouse_event_aware.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 // ------ MouseEventAware ------
 
@@ -28,7 +28,7 @@ pub trait MouseEventAware: UpdateRawEl + Sized {
                     y: event.y(),
                     movement_x: 0,
                     movement_y: 0,
-                    raw_event: RawMouseEvent::Click(event),
+                    raw_event: RawMouseEvent::Click(Arc::new(event)),
                 };
                 handler(mouse_event);
             })
@@ -47,7 +47,7 @@ pub trait MouseEventAware: UpdateRawEl + Sized {
                     y: event.y(),
                     movement_x: 0,
                     movement_y: 0,
-                    raw_event: RawMouseEvent::DoubleClick(event),
+                    raw_event: RawMouseEvent::DoubleClick(Arc::new(event)),
                 };
                 handler(mouse_event);
             })
@@ -78,7 +78,7 @@ pub trait MouseEventAware: UpdateRawEl + Sized {
                     y: event.y(),
                     movement_x: 0,
                     movement_y: 0,
-                    raw_event: RawMouseEvent::Click(event),
+                    raw_event: RawMouseEvent::Click(Arc::new(event)),
                 };
                 handler(mouse_event);
             })
@@ -119,7 +119,7 @@ pub trait MouseEventAware: UpdateRawEl + Sized {
                     y: event.y(),
                     movement_x: 0,
                     movement_y: 0,
-                    raw_event: RawMouseEvent::Click(event),
+                    raw_event: RawMouseEvent::Click(Arc::new(event)),
                 };
                 handler(mouse_event);
             })
@@ -155,6 +155,7 @@ fn is_inside(dom_element: &web_sys::Element, event: &events::Click, ids_selector
 
 // ------ MouseEvent ------
 
+#[derive(Clone)]
 pub struct MouseEvent {
     x: i32,
     y: i32,
@@ -183,7 +184,8 @@ impl MouseEvent {
 
 // ------ RawMouseEvent ------
 
+#[derive(Clone)]
 pub enum RawMouseEvent {
-    Click(events::Click),
-    DoubleClick(events::DoubleClick),
+    Click(Arc<events::Click>),
+    DoubleClick(Arc<events::DoubleClick>),
 }

--- a/crates/zoon/src/element/ability/mouse_event_aware.rs
+++ b/crates/zoon/src/element/ability/mouse_event_aware.rs
@@ -36,9 +36,9 @@ pub trait MouseEventAware: UpdateRawEl + Sized {
     }
 
     fn on_click_event_with_options(
-        self, 
-        options: EventOptions, 
-        mut handler: impl FnMut(MouseEvent) + 'static
+        self,
+        options: EventOptions,
+        mut handler: impl FnMut(MouseEvent) + 'static,
     ) -> Self {
         self.update_raw_el(|raw_el| {
             raw_el.event_handler_with_options(options, move |event: events::Click| {

--- a/crates/zoon/src/element/button.rs
+++ b/crates/zoon/src/element/button.rs
@@ -98,8 +98,16 @@ impl Button<LabelFlagNotSet, OnPressFlagNotSet, RawHtmlEl<web_sys::HtmlDivElemen
                         .style("margin-top", "auto")
                         .style("margin-bottom", "auto"),
                 )
-                .style_group(StyleGroup::new(".button > .align_top").style("margin-bottom", "auto"))
-                .style_group(StyleGroup::new(".button > .align_bottom").style("margin-top", "auto"))
+                .style_group(
+                    StyleGroup::new(".button > .align_top")
+                        .style("margin-bottom", "auto")
+                        .style("margin-top", "0")
+                    )
+                .style_group(
+                    StyleGroup::new(".button > .align_bottom")
+                        .style("margin-top", "auto")
+                        .style("margin-bottom", "0")
+                    )
                 .style_group(
                     StyleGroup::new(".button > .align_left").style("align-self", "flex-start"),
                 )

--- a/crates/zoon/src/element/button.rs
+++ b/crates/zoon/src/element/button.rs
@@ -101,13 +101,13 @@ impl Button<LabelFlagNotSet, OnPressFlagNotSet, RawHtmlEl<web_sys::HtmlDivElemen
                 .style_group(
                     StyleGroup::new(".button > .align_top")
                         .style("margin-bottom", "auto")
-                        .style("margin-top", "0")
-                    )
+                        .style("margin-top", "0"),
+                )
                 .style_group(
                     StyleGroup::new(".button > .align_bottom")
                         .style("margin-top", "auto")
-                        .style("margin-bottom", "0")
-                    )
+                        .style("margin-bottom", "0"),
+                )
                 .style_group(
                     StyleGroup::new(".button > .align_left").style("align-self", "flex-start"),
                 )
@@ -219,33 +219,36 @@ impl<'a, LabelFlag, OnPressFlag, RE: RawEl> Button<LabelFlag, OnPressFlag, RE> {
             .into_type()
     }
 
-    pub fn on_press_event(self, on_press: impl FnMut(ButtonPressEvent) + 'static) -> Button<LabelFlag, OnPressFlagSet, RE>
+    pub fn on_press_event(
+        self,
+        on_press: impl FnMut(ButtonPressEvent) + 'static,
+    ) -> Button<LabelFlag, OnPressFlagSet, RE>
     where
         OnPressFlag: FlagNotSet,
     {
         let on_click = Rc::new(RefCell::new(on_press));
         let on_enter_down = on_click.clone();
         self.on_click_event(move |event| {
-                let event = ButtonPressEvent::OnClick(event);
-                on_click.borrow_mut()(event);
+            let event = ButtonPressEvent::OnClick(event);
+            on_click.borrow_mut()(event);
+        })
+        .on_key_down_event(move |event| {
+            event.if_key(Key::Enter, {
+                let event = event.clone();
+                let on_enter_down = on_enter_down.clone();
+                move || {
+                    let event = ButtonPressEvent::OnEnterDown(event);
+                    on_enter_down.borrow_mut()(event);
+                }
             })
-            .on_key_down_event(move |event| {
-                event.if_key(Key::Enter, {
-                    let event = event.clone();
-                    let on_enter_down = on_enter_down.clone();
-                    move || {
-                        let event = ButtonPressEvent::OnEnterDown(event);
-                        on_enter_down.borrow_mut()(event);
-                    }
-                })
-            })
-            .into_type()
+        })
+        .into_type()
     }
 
     pub fn on_press_event_with_options(
         self,
         options: EventOptions,
-        on_press: impl FnMut(ButtonPressEvent) + 'static
+        on_press: impl FnMut(ButtonPressEvent) + 'static,
     ) -> Button<LabelFlag, OnPressFlagSet, RE>
     where
         OnPressFlag: FlagNotSet,
@@ -253,20 +256,20 @@ impl<'a, LabelFlag, OnPressFlag, RE: RawEl> Button<LabelFlag, OnPressFlag, RE> {
         let on_click = Rc::new(RefCell::new(on_press));
         let on_enter_down = on_click.clone();
         self.on_click_event_with_options(options, move |event| {
-                let event = ButtonPressEvent::OnClick(event);
-                on_click.borrow_mut()(event);
+            let event = ButtonPressEvent::OnClick(event);
+            on_click.borrow_mut()(event);
+        })
+        .on_key_down_event_with_options(options, move |event| {
+            event.if_key(Key::Enter, {
+                let event = event.clone();
+                let on_enter_down = on_enter_down.clone();
+                move || {
+                    let event = ButtonPressEvent::OnEnterDown(event);
+                    on_enter_down.borrow_mut()(event);
+                }
             })
-            .on_key_down_event_with_options(options, move |event| {
-                event.if_key(Key::Enter, {
-                    let event = event.clone();
-                    let on_enter_down = on_enter_down.clone();
-                    move || {
-                        let event = ButtonPressEvent::OnEnterDown(event);
-                        on_enter_down.borrow_mut()(event);
-                    }
-                })
-            })
-            .into_type()
+        })
+        .into_type()
     }
 
     fn into_type<NewLabelFlag, NewOnPressFlag>(self) -> Button<NewLabelFlag, NewOnPressFlag, RE> {

--- a/crates/zoon/src/event_options.rs
+++ b/crates/zoon/src/event_options.rs
@@ -1,6 +1,8 @@
+use crate::*;
+
 #[derive(Copy, Clone, Debug, Default)]
 pub struct EventOptions {
-    bubbles: bool,
+    parents_first: bool,
     preventable: bool,
 }
 
@@ -9,8 +11,8 @@ impl EventOptions {
         Self::default()
     }
 
-    pub fn bubbles(mut self) -> Self {
-        self.bubbles = true;
+    pub fn parents_first(mut self) -> Self {
+        self.parents_first = true;
         self
     }
 
@@ -23,7 +25,7 @@ impl EventOptions {
 impl From<EventOptions> for dominator::EventOptions {
     fn from(options: EventOptions) -> Self {
         Self {
-            bubbles: options.bubbles,
+            bubbles: not(options.parents_first),
             preventable: options.preventable,
         }
     }


### PR DESCRIPTION
- New `Button` methods `on_press_event` and `on_press_event_with_options`.
- New event `ButtonPressEvent`.
- _[Breaking]_ `EventOptions::bubbles` renamed to `parents_first` and it's `false` by default.
- New method `pass_to_parent(bool)` added to `KeyboardEvent`, `RawKeyboardEvent`, `MouseEvent` and `RawMouseEvent`.
- `Clone` implemented for `KeyboardEvent`, `RawKeyboardEvent`, `MouseEvent` and `RawMouseEvent`.
- New `MouseEventAware` method `on_click_event_with_options`.