### PR TITLE
make new tab api zoonic

### DIFF
--- a/crates/zoon/src/element/link.rs
+++ b/crates/zoon/src/element/link.rs
@@ -20,12 +20,14 @@ impl NewTab {
         }
     }
 
-    pub fn refer(&mut self, value: bool) {
+    pub fn refer(mut self, value: bool) -> Self {
         self.refer = value;
+        self
     }
 
-    pub fn follow(&mut self, value: bool) {
+    pub fn follow(mut self, value: bool) -> Self {
         self.follow = value;
+        self
     }
 }
 


### PR DESCRIPTION
the new tab options api is not zoonic as described [here](https://github.com/MoonZoon/MoonZoon/pull/122#issuecomment-1187366878), so it errors with the chained syntax e.g. `NewTab::new().refer(false).follow(false)`, this fixes that