### PR TITLE
Font::family_signal

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,6 +1,5 @@
 extend = "./default_makefile.toml"
 
-# @TODO refactor once https://github.com/sagiegurari/cargo-make/issues/667 is resolved
 [tasks.in_examples]
 description = '''
 Run chosen task for each example in its root.
@@ -10,9 +9,7 @@ script = [
 '''
 #!@duckscript
 handle = glob_array examples/*/Makefile.toml
-
-args = array ${1} ${2} ${3} ${4} ${5}
-args_string = array_join ${args} " "
+args_string = array_join ${@} " "
 
 for path in ${handle}
     example_root = dirname ${path}

--- a/default_makefile.toml
+++ b/default_makefile.toml
@@ -1,6 +1,6 @@
 [config]
 default_to_workspace = false
-min_version = "0.35.13"
+min_version = "0.35.15"
 unstable_features = ["CTRL_C_HANDLING"]
 skip_core_tasks = true
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,7 @@ _WARNING:_ MoonZoon is in the phase of early development and a CI pipeline / lin
 - [cargo-make](https://sagiegurari.github.io/cargo-make/)
   ```bash
   cargo install cargo-make --no-default-features
-  makers -V # makers 0.35.13
+  makers -V # makers 0.35.15
   ```
   - _Note_: `cargo-make` is needed only for MoonZoon development and running its examples, you don't need it for your apps.
 


### PR DESCRIPTION
- Add `Font::family_signal` (resolves #127).
- Fix `Font::family` when `None` or another empty iterator is used.
- Minor refactor of `Makefile.toml`.