### PR TITLE
change named colors to const

### DIFF
--- a/crates/zoon/src/style/named_color.rs
+++ b/crates/zoon/src/style/named_color.rs
@@ -12,7 +12,7 @@
 //! ```
 use crate::*;
 
-/// Create a `static` `HSluv` color from a color name, hue, saturation and lightness.
+/// Create a `const` `HSluv` color from a color name, hue, saturation and lightness.
 macro_rules! color {
     ($color:ident => $h:literal, $s:literal, $l:literal) => {
         pub const $color: HSLuv = hsluv!($h, $s, $l);

--- a/crates/zoon/src/style/named_color.rs
+++ b/crates/zoon/src/style/named_color.rs
@@ -15,11 +15,11 @@ use crate::*;
 /// Create a `static` `HSluv` color from a color name, hue, saturation and lightness.
 macro_rules! color {
     ($color:ident => $h:literal, $s:literal, $l:literal) => {
-        pub static $color: HSLuv = hsluv!($h, $s, $l);
+        pub const $color: HSLuv = hsluv!($h, $s, $l);
     };
 }
 
-pub static TRANSPARENT: HSLuv = hsluv!(0, 0, 0, 0);
+pub const TRANSPARENT: HSLuv = hsluv!(0, 0, 0, 0);
 
 color!(GRAY_0 => 235.5, 22.1, 98.2);
 color!(GRAY_1 => 248.2, 18.5, 96.2);


### PR DESCRIPTION
I want to make styles in from of `const`s. To be able to define a `const` color scheme, I need the `named_colors` to be `const`.