### PR TITLE
Silent routing, Timer fix, SignalMapExtExt

### DIFF
--- a/crates/zoon/src/futures_signals_ext.rs
+++ b/crates/zoon/src/futures_signals_ext.rs
@@ -6,3 +6,6 @@ pub use signal_ext_option::*;
 
 mod signal_ext_ext;
 pub use signal_ext_ext::*;
+
+mod signal_map_ext_ext;
+pub use signal_map_ext_ext::*;

--- a/crates/zoon/src/futures_signals_ext/signal_map_ext_ext.rs
+++ b/crates/zoon/src/futures_signals_ext/signal_map_ext_ext.rs
@@ -1,0 +1,50 @@
+use crate::*;
+use std::{
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+// ------ SignalMapExtExt ------
+
+pub trait SignalMapExtExt: SignalMapExt {
+    #[inline]
+    fn for_each_sync<F>(self, mut callback: F) -> ForEachSync<Self, F>
+    where
+        F: FnMut(MapDiff<Self::Key, Self::Value>) + 'static,
+        Self: 'static + Sized,
+    {
+        ForEachSync {
+            future: self
+                .for_each(move |item| {
+                    callback(item);
+                    async {}
+                })
+                .boxed_local(),
+            signal: PhantomData,
+            callback: PhantomData,
+        }
+    }
+}
+
+impl<S: SignalMapExt> SignalMapExtExt for S {}
+
+// -- ForEachSync --
+
+#[pin_project(project = ForEachSyncProj)]
+#[must_use = "Futures do nothing unless polled"]
+pub struct ForEachSync<S, F> {
+    #[pin]
+    future: future::LocalBoxFuture<'static, ()>,
+    signal: PhantomData<S>,
+    callback: PhantomData<F>,
+}
+
+impl<S: SignalMap, F: FnMut(MapDiff<S::Key, S::Value>)> Future for ForEachSync<S, F> {
+    type Output = ();
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        self.project().future.poll(cx)
+    }
+}

--- a/crates/zoon/src/lib.rs
+++ b/crates/zoon/src/lib.rs
@@ -48,6 +48,10 @@ pub use futures_signals::{
         self, always, channel, Broadcaster, MutableSignal, ReadOnlyMutable, Receiver, Sender,
         Signal, SignalExt, SignalStream,
     },
+    // @TODO Uncomment once and remove the next line once the new `futures-signals` version is released
+    // (Note: Patch in Cargo.toml does not work)
+    // (related PR: https://github.com/Pauan/rust-signals/pull/65)
+    // signal_map::{always as always_map, MapDiff, MutableBTreeMap, MutableSignalMap, SignalMap, SignalMapExt},
     signal_map::{MapDiff, MutableBTreeMap, MutableSignalMap, SignalMap, SignalMapExt},
     signal_vec::{always as always_vec, MutableSignalVec, SignalVec, SignalVecExt, VecDiff},
 };

--- a/crates/zoon/src/lib.rs
+++ b/crates/zoon/src/lib.rs
@@ -51,7 +51,7 @@ pub use futures_signals::{
     signal_map::{MapDiff, MutableBTreeMap, MutableSignalMap, SignalMap, SignalMapExt},
     signal_vec::{always as always_vec, MutableSignalVec, SignalVec, SignalVecExt, VecDiff},
 };
-pub use futures_signals_ext::{SignalExtBool, SignalExtExt, SignalExtOption};
+pub use futures_signals_ext::{SignalExtBool, SignalExtExt, SignalExtOption, SignalMapExtExt};
 pub use futures_util::{self, future, FutureExt, Stream, StreamExt};
 pub use gensym::gensym;
 pub use hsluv::{hsluv, HSLuv};

--- a/crates/zoon/src/lib.rs
+++ b/crates/zoon/src/lib.rs
@@ -48,8 +48,8 @@ pub use futures_signals::{
         self, always, channel, Broadcaster, MutableSignal, ReadOnlyMutable, Receiver, Sender,
         Signal, SignalExt, SignalStream,
     },
-    signal_map::{MutableBTreeMap, MutableSignalMap, SignalMap, SignalMapExt},
-    signal_vec::{always as always_vec, MutableSignalVec, SignalVec, SignalVecExt},
+    signal_map::{MapDiff, MutableBTreeMap, MutableSignalMap, SignalMap, SignalMapExt},
+    signal_vec::{always as always_vec, MutableSignalVec, SignalVec, SignalVecExt, VecDiff},
 };
 pub use futures_signals_ext::{SignalExtBool, SignalExtExt, SignalExtOption};
 pub use futures_util::{self, future, FutureExt, Stream, StreamExt};

--- a/crates/zoon/src/timer.rs
+++ b/crates/zoon/src/timer.rs
@@ -17,7 +17,8 @@ impl Timer {
         }
     }
 
-    pub fn new_immediate(ms: u32, on_tick: impl FnMut() + 'static) -> Self {
+    pub fn new_immediate(ms: u32, mut on_tick: impl FnMut() + 'static) -> Self {
+        on_tick();
         Self::new(ms, on_tick)
     }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,7 @@ _WARNING:_ MoonZoon is in the phase of early development and a CI pipeline / lin
 - [cargo-make](https://sagiegurari.github.io/cargo-make/)
   ```bash
   cargo install cargo-make --no-default-features
-  makers -V # cargo-make 0.36.4
+  makers -V # cargo-make 0.36.6
   ```
   - _Note_: `cargo-make` is needed only for MoonZoon development and running its examples, you don't need it for your apps.
 


### PR DESCRIPTION
- Extend `SignalMap` with the method `for_each_sync`.
- Fix `Timer::new_immediate`.
- Add `Router` methods `silent_go` and `silent_replace`.