### PR TITLE
Fix #app element height on desktop Safari

### DIFF
--- a/crates/moon/css/basic.css
+++ b/crates/moon/css/basic.css
@@ -29,10 +29,16 @@ body * {
     height: 100vh;
 }
 
-@supports (height: 100dvh) { 
-    #app {
-        /* @TODO Move to #app block once https://caniuse.com/viewport-unit-variants are supported. */
-        height: 100dvh; 
+/* smartphones, touchscreens (https://ferie.medium.com/detect-a-touch-device-with-only-css-9f8e30fa1134) */
+@media (hover: none) and (pointer: coarse) {
+    @supports (height: 100dvh) { 
+        #app {
+            /* @TODO Move to #app block once https://caniuse.com/viewport-unit-variants are supported 
+                and it works as expected on desktop Safari.
+                Note: When more granularity is needed: https://stackoverflow.com/a/25975282 
+            */
+            height: 100dvh; 
+        }
     }
 }
 


### PR DESCRIPTION
- Fix `#app` element height on desktop Safari.
   - Safari finally supports `dvh` unit but it doesn't work properly (tested with Safari 15.6.1) 