### PR TITLE
Fix failing wasm-opt optimization when mzoon release build in MacOS

### DIFF
--- a/crates/mzoon/new_project/.gitignore
+++ b/crates/mzoon/new_project/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/crates/mzoon/src/wasm_opt.rs
+++ b/crates/mzoon/src/wasm_opt.rs
@@ -68,7 +68,7 @@ pub async fn optimize_with_wasm_opt(build_mode: BuildMode) {
     if let BuildMode::Profiling = build_mode {
         args.push("--debuginfo");
     }
-    Command::new("frontend/wasm-opt")
+    Command::new("frontend/binaryen/bin/wasm-opt")
         .args(&args)
         .status()
         .await
@@ -83,7 +83,7 @@ pub async fn optimize_with_wasm_opt(build_mode: BuildMode) {
 async fn check_wasm_opt() {
     const EXPECTED_VERSION_OUTPUT_START: &[u8] = concatcp!("wasm-opt version ", VERSION).as_bytes();
 
-    let version_output = Command::new("frontend/wasm-opt")
+    let version_output = Command::new("frontend/binaryen/bin/wasm-opt")
         .args(&["--version"])
         .output()
         .await?

--- a/crates/mzoon/src/wasm_opt.rs
+++ b/crates/mzoon/src/wasm_opt.rs
@@ -51,6 +51,7 @@ pub async fn check_or_install_wasm_opt() {
             "Failed to download wasm-opt from the url '{DOWNLOAD_URL}'"
         ))?
         .apply(unpack_wasm_opt)
+        .await
         .context("Failed to unpack wasm-opt")?;
     println!("wasm-opt installed");
 }
@@ -99,7 +100,7 @@ async fn check_wasm_opt() {
 }
 
 #[throws]
-fn unpack_wasm_opt(tar_gz: Vec<u8>) {
+async fn unpack_wasm_opt(tar_gz: Vec<u8>) {
     const LIBBINARYEN_PATH: &str = "frontend/binaryen/lib/libbinaryen.dylib";
 
     let tar = GzDecoder::new(tar_gz.as_slice());
@@ -124,7 +125,7 @@ fn unpack_wasm_opt(tar_gz: Vec<u8>) {
         entry.unpack(destination)?;
     }
 
-    if !(PathBuf::from("frontend/binaryen/bin/wasm-opt").exists() && PathBuf::from("frontend/binaryen/lib/libbinaryen.dylib").exists()) {
-        Err(anyhow!("Failed to find wasm-opt in the downloaded archive"))?
-    };
+    if let Err(error) = check_wasm_opt().await {
+        eprintln!("wasm-opt installation failed: {error:#}");
+    }
 }

--- a/crates/mzoon/src/wasm_opt.rs
+++ b/crates/mzoon/src/wasm_opt.rs
@@ -6,12 +6,13 @@ use cfg_if::cfg_if;
 use const_format::{concatcp, formatcp};
 use fehler::throws;
 use flate2::read::GzDecoder;
-use std::path::PathBuf;
 use std::fs::create_dir_all;
+use std::path::PathBuf;
 use tar::Archive;
 use tokio::process::Command;
 
 const VERSION: &str = "110";
+const WASM_OPT_PATH: &str = "frontend/binaryen/bin/wasm-opt";
 
 // -- public --
 
@@ -68,7 +69,7 @@ pub async fn optimize_with_wasm_opt(build_mode: BuildMode) {
     if let BuildMode::Profiling = build_mode {
         args.push("--debuginfo");
     }
-    Command::new("frontend/binaryen/bin/wasm-opt")
+    Command::new(WASM_OPT_PATH)
         .args(&args)
         .status()
         .await
@@ -83,7 +84,7 @@ pub async fn optimize_with_wasm_opt(build_mode: BuildMode) {
 async fn check_wasm_opt() {
     const EXPECTED_VERSION_OUTPUT_START: &[u8] = concatcp!("wasm-opt version ", VERSION).as_bytes();
 
-    let version_output = Command::new("frontend/binaryen/bin/wasm-opt")
+    let version_output = Command::new(WASM_OPT_PATH)
         .args(&["--version"])
         .output()
         .await?

--- a/examples/align/.gitignore
+++ b/examples/align/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/align_content/.gitignore
+++ b/examples/align_content/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/canvas/.gitignore
+++ b/examples/canvas/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/chat/.gitignore
+++ b/examples/chat/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/counter/.gitignore
+++ b/examples/counter/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/counters/.gitignore
+++ b/examples/counters/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/custom_config/.gitignore
+++ b/examples/custom_config/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 
 # The line below commented out for the example purposes.

--- a/examples/custom_http_client/.gitignore
+++ b/examples/custom_http_client/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/image/.gitignore
+++ b/examples/image/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/js_framework_benchmark/.gitignore
+++ b/examples/js_framework_benchmark/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/js_text_editor/.gitignore
+++ b/examples/js_text_editor/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/keyboard/.gitignore
+++ b/examples/keyboard/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/layers/.gitignore
+++ b/examples/layers/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/markup/.gitignore
+++ b/examples/markup/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/minesweeper/.gitignore
+++ b/examples/minesweeper/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/pages/.gitignore
+++ b/examples/pages/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/pan_zoom/.gitignore
+++ b/examples/pan_zoom/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/paragraph/.gitignore
+++ b/examples/paragraph/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/resize_drag/.gitignore
+++ b/examples/resize_drag/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/row_wrap/.gitignore
+++ b/examples/row_wrap/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/slider/.gitignore
+++ b/examples/slider/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/spinner/.gitignore
+++ b/examples/spinner/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/start_with_app/.gitignore
+++ b/examples/start_with_app/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/svg/.gitignore
+++ b/examples/svg/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/text_area/.gitignore
+++ b/examples/text_area/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/time_tracker/.gitignore
+++ b/examples/time_tracker/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/timer/.gitignore
+++ b/examples/timer/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/todomvc/.gitignore
+++ b/examples/todomvc/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/tweened/.gitignore
+++ b/examples/tweened/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/video/.gitignore
+++ b/examples/video/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/viewport/.gitignore
+++ b/examples/viewport/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/wasm_components/.gitignore
+++ b/examples/wasm_components/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api

--- a/examples/web_components/.gitignore
+++ b/examples/web_components/.gitignore
@@ -1,6 +1,6 @@
 target
 frontend/wasm-bindgen*
-frontend/wasm-opt*
+frontend/binaryen
 frontend/pkg
 MoonZoonCustom.toml
 frontend_dist/_api


### PR DESCRIPTION
related #116 

## Summary

Currently when installing wasm-opt in `mzoon build --release` command, only the executable of wasm-opt is installed. This PR makes `mzoon` command install not just the wasm-opt itself but also its dynamic library `libbinaryen.dylib` picking from the same downloaded package.

As indicated in the error message in the background section below, the `libbinaryen.dylib` must be placed in the dedicated path relative to the wasm-opt executable. To make the dylib available from wasm-opt, they will be installed into a new directory `binaryen`, meaning that this PR changes the file structure in the `frontend/` directory after `mzoon build --release` command invocation from/to:

```
### BEFORE (without this PR)
frontend
├ src/
├ pkg/
├ Cargo.toml
├ wasm-bindgen
└ wasm-opt(.exe)

---
### AFTER (this PR takes effect)
frontend
├ src/
├ pkg/
├ Cargo.toml
├ wasm-bindgen
└ binaryen/
   ├ bin/wasm-opt(.exe)
   └ lib/libbinaryen(.dylib / .a)
```

## Background

The command `mzoon build --release --frontend-dist netlify` fails in MacOS environments when wasm-opt cannot find the binaryen dynamic library (namely `libbinaryen.dylib`) in its search path.

In the case of my machine (Intel Mac), the error message looks like:

```
$ mzoon build --release --frontend-dist netlify
Build { release: true, profiling: false, frontend_dist: true, hosting: Some(Netlify) }
Building frontend...
    Finished release [optimized] target(s) in 0.88s
Downloading & Installing wasm-bindgen 0.2.84 ...
wasm-bindgen installed
Downloading & Installing wasm-opt 110 ...
Pre-compiled wasm-opt binary 'x86_64-macos' will be used for the target platform 'x86_64-apple-darwin'
wasm-opt installed
dyld[9713]: Library not loaded: @rpath/libbinaryen.dylib
  Referenced from: <88104CCB-579F-32A7-A999-5EB71FD662E3> /Users/etoal/projects/etoal-homepage/frontend/wasm-opt
  Reason: tried: '/Users/etoal/projects/etoal-homepage/frontend/../lib/libbinaryen.dylib' (no such file), '/Users/etoal/projects/etoal-homepage/frontend/../lib/libbinaryen.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS@rpath/libbinaryen.dylib' (no such file), '/Users/etoal/projects/etoal-homepage/frontend/../lib/libbinaryen.dylib' (no such file), '/Users/etoal/projects/etoal-homepage/frontend/../lib/libbinaryen.dylib' (no such file), '/usr/local/lib/libbinaryen.dylib' (no such file), '/usr/lib/libbinaryen.dylib' (no such file, not in dyld cache)
Error: Failed to optimize frontend with wasm-opt
```
