### PR TITLE
Transparent tauri_ipc example

### DIFF
--- a/crates/zoon/src/color.rs
+++ b/crates/zoon/src/color.rs
@@ -2,7 +2,7 @@ mod into_color;
 
 pub mod color_space;
 
-// Warning: Oklch works properly only on Safari >= 16.2 
+// Warning: Oklch works properly only on Safari >= 16.2
 // https://github.com/saadeghi/daisyui/issues/2703#issuecomment-1969865934
 
 pub use color_macro::color;

--- a/examples/tauri_ipc/README.md
+++ b/examples/tauri_ipc/README.md
@@ -45,3 +45,10 @@ Troubleshooting:
 12. Enable `tauri` crate feature `linux-ipc-protocol` in `src-tauri/Cargo.toml` to make IPC faster on Linux.
 13. Change `app.withGlobalTauri` in `src-tauri/tauri.conf.json` to `true`.
 14. Add `"center": true` and `visible": false` to the first window config in `app.windows` in `src-tauri/tauri.conf.json`.
+15. Add `"titleBarStyle": Transparent` to the first window config in `app.windows` in `src-tauri/tauri.conf.json`.
+
+### Title bar styling and customizations
+
+- https://www.youtube.com/watch?v=zsaWFf2LEv4
+- https://beta.tauri.app/references/v2/config/#titlebarstyle
+- https://docs.rs/tauri-utils/2.0.0-beta.11/tauri_utils/enum.TitleBarStyle.html

--- a/examples/tauri_ipc/README.md
+++ b/examples/tauri_ipc/README.md
@@ -42,13 +42,21 @@ Troubleshooting:
 9. Add `"src-tauri"` to `Cargo.toml` workspace members.
 10. Change `identifier` in `src-tauri/tauri.conf.json` to `"com.example.moonzoon.tauri-ipc"`
 11. Set env var `WEBKIT_DISABLE_DMABUF_RENDERER=1` in `src-tauri/lib.rs` because WebKitGTK (2.42) is not compatible with NVIDIA drivers on Linux.
-12. Enable `tauri` crate feature `linux-ipc-protocol` in `src-tauri/Cargo.toml` to make IPC faster on Linux.
+12. Enable `tauri` crate feature `linux-ipc-protocol` and `macos-private-api` in `src-tauri/Cargo.toml`.
 13. Change `app.withGlobalTauri` in `src-tauri/tauri.conf.json` to `true`.
+13. Add "macOSPrivateApi": true` in `app` in `src-tauri/tauri.conf.json`.
 14. Add `"center": true` and `visible": false` to the first window config in `app.windows` in `src-tauri/tauri.conf.json`.
-15. Add `"titleBarStyle": Transparent` to the first window config in `app.windows` in `src-tauri/tauri.conf.json`.
+15. Add `"titleBarStyle": "Transparent"` to the first window config in `app.windows` in `src-tauri/tauri.conf.json`.
+16. Add `"transparent": true` to the first window config in `app.windows` in `src-tauri/tauri.conf.json`.
+
+### Transparent window
+
+- https://beta.tauri.app/references/v2/config/#transparent
+- From the doc above: _"Note that on macOS this requires the macos-private-api feature flag, enabled under tauri &gt; macOSPrivateApi. WARNING: Using private APIs on macOS prevents your application from being accepted to the App Store."_
 
 ### Title bar styling and customizations
 
 - https://www.youtube.com/watch?v=zsaWFf2LEv4
 - https://beta.tauri.app/references/v2/config/#titlebarstyle
 - https://docs.rs/tauri-utils/2.0.0-beta.11/tauri_utils/enum.TitleBarStyle.html
+- _Note_: To make the title bar transparent, you have to set `"macOSPrivateApi": true` like in the case of transparent window described above.

--- a/examples/tauri_ipc/README.md
+++ b/examples/tauri_ipc/README.md
@@ -19,6 +19,12 @@ Troubleshooting:
     ```
     Fix it by installing VSCode directly from official `.deb` bundle or try to unset multiple env variables - more info in https://stackoverflow.com/questions/75921414/java-symbol-lookup-error-snap-core20-current-lib-x86-64-linux-gnu-libpthread
 
+- There is a noticeable lag when clicking global menu items on macOS.
+  - It seems to be a macOS feature, not a bug. The same lag happens even when e.g. closing a native macOS System Settings though its menu (File -> Close).
+  - https://github.com/electron/electron/issues/6498
+  - https://apple.stackexchange.com/questions/199890/why-do-menu-items-blink-twice-when-selected
+  - https://apple.stackexchange.com/questions/293167/how-can-i-disable-menu-blinking-after-selecting-a-menu-item-in-macos
+
 ---
 
 ### Production build:

--- a/examples/tauri_ipc/frontend/src/main.rs
+++ b/examples/tauri_ipc/frontend/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
 fn root() -> impl Element {
     El::new()
         .s(Height::fill())
-        .s(Background::new().color(color!("DarkSlateBlue")))
+        .s(Background::new().color(color!("DarkSlateBlue", 0.7)))
         .s(Font::new().color(color!("Lavender")))
         .child(
             Column::new()

--- a/examples/tauri_ipc/src-tauri/Cargo.toml
+++ b/examples/tauri_ipc/src-tauri/Cargo.toml
@@ -20,5 +20,5 @@ tauri-build = { version = "2.0.0-beta.10", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "2.0.0-beta.13", features = ["linux-ipc-protocol"] }
+tauri = { version = "2.0.0-beta.13", features = ["macos-private-api", "linux-ipc-protocol"] }
 # tauri-bindgen-host = { git = "https://github.com/tauri-apps/tauri-bindgen", rev = "5eabe7b96c7b77f37d82bd2fe519a9e3e1377c52" }

--- a/examples/tauri_ipc/src-tauri/tauri.conf.json
+++ b/examples/tauri_ipc/src-tauri/tauri.conf.json
@@ -13,6 +13,7 @@
     "windows": [
       {
         "title": "Tauri IPC",
+        "titleBarStyle": "Transparent",
         "width": 800,
         "height": 600,
         "resizable": true,

--- a/examples/tauri_ipc/src-tauri/tauri.conf.json
+++ b/examples/tauri_ipc/src-tauri/tauri.conf.json
@@ -9,6 +9,7 @@
     "beforeBuildCommand": "makers mzoon build -r -f"
   },
   "app": {
+    "macOSPrivateApi": true,
     "withGlobalTauri": true,
     "windows": [
       {
@@ -19,7 +20,8 @@
         "resizable": true,
         "fullscreen": false,
         "center": true,
-        "visible": false
+        "visible": false,
+        "transparent": true
       }
     ],
     "security": {


### PR DESCRIPTION
![tauri_ipc_macos_screeenshot](https://github.com/MoonZoon/MoonZoon/assets/18517402/02504dd3-cbf6-4bac-86a3-f9fa76fd8188)

Tauri IPC example changes:
- Transparent title bar (only on macOS).
- Transparent background.
- All "Greet Tom" events are displayed as a list.
- README updated with info about:
   - Noticeable menu item lag on macOS
   - Making the window background transparent
   - Title bar styling