### PR TITLE
remove duplicate package `app` warning when installing MoonZoon via git 

### DIFF
--- a/examples/tauri_ipc/src-tauri/Cargo.toml
+++ b/examples/tauri_ipc/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "app"
+name = "tauri_ipc"
 version = "0.1.0"
 description = "Tauri Web FS"
 authors = ["Martin Kavík <martin@kavik.cz>"]

--- a/examples/tauri_local_search/src-tauri/Cargo.toml
+++ b/examples/tauri_local_search/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "app"
+name = "tauri_local_search"
 version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]

--- a/examples/tauri_todomvc/src-tauri/Cargo.toml
+++ b/examples/tauri_todomvc/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "app"
+name = "tauri_todomvc"
 version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]

--- a/examples/tauri_web_workers/src-tauri/Cargo.toml
+++ b/examples/tauri_web_workers/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "app"
+name = "tauri_web_workers"
 version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]


### PR DESCRIPTION
these warning show up when installing MoonZoon via git
```
warning: skipping duplicate package `app` found at `/home/avi/.cargo/git/checkouts/moonzoon-b4ee803417068292/a8b351c/examples/tauri_todomvc/src-tauri`
warning: skipping duplicate package `app` found at `/home/avi/.cargo/git/checkouts/moonzoon-b4ee803417068292/a8b351c/examples/tauri_ipc/src-tauri`
warning: skipping duplicate package `app` found at `/home/avi/.cargo/git/checkouts/moonzoon-b4ee803417068292/a8b351c/examples/tauri_local_search/src-tauri`
```
this is a known issue with cargo https://github.com/rust-lang/cargo/issues/10752

simply renaming these packages suffices to remove these warnings